### PR TITLE
Update grammar in REST vs RPC section

### DIFF
--- a/docs/microservices/api-design.md
+++ b/docs/microservices/api-design.md
@@ -28,7 +28,7 @@ Here are some things to think about when choosing how to implement an API.
 
 **REST vs RPC**. Consider the tradeoffs between using a REST-style interface versus an RPC-style interface.
 
-- REST models resources, which can be a natural way express your domain model. It defines a uniform interface based on HTTP verbs, which encourages evolvability. It has well-defined semantics in terms of idempotency, side effects, and response codes. And it enforces stateless communication, which improves scalability.
+- REST models resources can be a natural way to express your domain model. It defines a uniform interface based on HTTP verbs, which encourages evolvability. It has well-defined semantics in terms of idempotency, side effects, and response codes. And it enforces stateless communication, which improves scalability.
 
 - RPC is more oriented around operations or commands. Because RPC interfaces look like local method calls, it may lead you to design overly chatty APIs. However, that doesn't mean RPC must be chatty. It just means you need to use care when designing the interface.
 

--- a/docs/microservices/api-design.md
+++ b/docs/microservices/api-design.md
@@ -28,7 +28,7 @@ Here are some things to think about when choosing how to implement an API.
 
 **REST vs RPC**. Consider the tradeoffs between using a REST-style interface versus an RPC-style interface.
 
-- REST models resources can be a natural way to express your domain model. It defines a uniform interface based on HTTP verbs, which encourages evolvability. It has well-defined semantics in terms of idempotency, side effects, and response codes. And it enforces stateless communication, which improves scalability.
+- REST models resources. REST can be a natural way to express your domain model. It defines a uniform interface based on HTTP verbs, which encourages evolvability. It has well-defined semantics in terms of idempotency, side effects, and response codes. And it enforces stateless communication, which improves scalability.
 
 - RPC is more oriented around operations or commands. Because RPC interfaces look like local method calls, it may lead you to design overly chatty APIs. However, that doesn't mean RPC must be chatty. It just means you need to use care when designing the interface.
 


### PR DESCRIPTION
The first sentence of the REST section is grammatically incorrect and awkward sounding. There are a few ways to fix it but I think this edit makes the most sense as it presents the information in a similar manner as the next paragraph on RPC.