### PR TITLE
Update index.md to correct formulae for Composite SLAs

### DIFF
--- a/docs/resiliency/index.md
+++ b/docs/resiliency/index.md
@@ -151,8 +151,8 @@ Let *N* be the composite SLA for the application deployed in one region, and *R*
 
 For example, if the single-region SLA is 99.95%,
 
-- The combined SLA for two regions = (1 &minus; (0.9995 ^ 2)) = 99.999975%
-- The combined SLA for four regions = (1 &minus; (0.9995 ^ 4)) = 99.999999%
+- The combined SLA for two regions = (1 &minus; (1 &minus; 0.9995) ^ 2) = 99.999975%
+- The combined SLA for four regions = (1 &minus; (1 &minus; 0.9995) ^ 4) = 99.999999%
 
 You must also factor in the [SLA for Traffic Manager][tm-sla]. At the time of this writing, the SLA for Traffic Manager SLA is 99.99%.
 


### PR DESCRIPTION
The Composite SLA Calculator formulae look to be incorrect. I'm sure the intent is correct - that composing 2x 99.95% SLAs in a HA environment raises the SLA, but if you follow the formula given it shows a reduction in the SLA rather than an increase.
The Formula in question:
The combined SLA for two regions = (1 − (0.9995 ^ 2)) = 99.999975%
If you raise 0.9995 to the power 2, you get 0.999. Subtract this from 1 and you get 0.001.
To arrive at the numbers you're suggesting should come from this formula (assuming they are correct?), should the formula not be:
1-(1-0.9995)^2 = 99.999975%

NOTE: I raised an issue for this (which I will now close, but decided I'd try and fix it myself - first ever pull request, so please be gentle :D)