### PR TITLE
Why the -rg in the end of the RG name?

### DIFF
--- a/docs/best-practices/naming-conventions.md
+++ b/docs/best-practices/naming-conventions.md
@@ -76,7 +76,7 @@ In general, avoid having any special characters (`-` or `_`) as the first or las
 
 | Entity | Scope | Length | Casing | Valid Characters | Suggested Pattern | Example |
 | --- | --- | --- | --- | --- | --- | --- |
-|Resource Group |Subscription |1-90 |Case insensitive |Alphanumeric, underscore, parentheses, hyphen, period (except at end), and Unicode characters that match the regex documented [here](/rest/api/resources/resourcegroups/createorupdate). |`<service short name>-<environment>-rg` |`profx-prod-rg` |
+|Resource Group |Subscription |1-90 |Case insensitive |Alphanumeric, underscore, parentheses, hyphen, period (except at end), and Unicode characters that match the regex documented [here](/rest/api/resources/resourcegroups/createorupdate). |`<service short name>-<environment>` |`profx-prod` |
 |Availability Set |Resource Group |1-80 |Case insensitive |Alphanumeric, underscore, and hyphen |`<service-short-name>-<context>-as` |`profx-sql-as` |
 |Tag |Associated Entity |512 (name), 256 (value) |Case insensitive |Alphanumeric, special characters except `<`, `>`, `%`, `&`, `\`, `?`, `/`. See limitations [here](/azure/azure-resource-manager/resource-group-using-tags). |`"key" : "value"` |`"department" : "Central IT"` |
 


### PR DESCRIPTION
We're having a hard time convincing customers that they shouldnt name their RG's "-rg".
We think it is not needed, as you can always see it is an RG, and we don't want to have in on each as it just wastes space and looks "weird"

We think that it should be removed from these guidelines, if not, we would love to know why it is recommended, as, from our point of view, it does not make sense.

best regards
Jakob