### PR TITLE
Fix a link to event-sourcing page in cqrs.md

### DIFF
--- a/docs/patterns/cqrs.md
+++ b/docs/patterns/cqrs.md
@@ -57,7 +57,7 @@ The read store can be a read-only replica of the write store, or the read and wr
 
 Separation of the read and write stores also allows each to be scaled appropriately to match the load. For example, read stores typically encounter a much higher load than write stores.
 
-Some implementations of CQRS use the [Event Sourcing pattern][event-sourcing]. With this pattern, application state is stored as a sequence of events. Each event represents a set of changes to the data. The current state is constructed by replaying the events. In a CQRS context, one benefit of Event Sourcing is that the same events can be used to notify other components &mdash; in particular, to notify the read model. The read model uses the events to create a snapshot of the current state, which is more efficient for queries. However, Event Sourcing adds complexity to the design.
+Some implementations of CQRS use the [Event Sourcing pattern](./event-sourcing.md). With this pattern, application state is stored as a sequence of events. Each event represents a set of changes to the data. The current state is constructed by replaying the events. In a CQRS context, one benefit of Event Sourcing is that the same events can be used to notify other components &mdash; in particular, to notify the read model. The read model uses the events to create a snapshot of the current state, which is more efficient for queries. However, Event Sourcing adds complexity to the design.
 
 Benefits of CQRS include:
 


### PR DESCRIPTION
The link to "Event Sourcing pattern" page under "Solution" section was using wrong parenthesis and wasn't rendered correctly.
Fixed the link to align with another link in "Event Sourcing and CQRS" section in the same page.