### PR TITLE
Add NServiceBus sample to Publisher/Subscriber doc

### DIFF
--- a/docs/patterns/publisher-subscriber.md
+++ b/docs/patterns/publisher-subscriber.md
@@ -127,3 +127,5 @@ The following patterns and guidance might be relevant when implementing this pat
 - [Observer Pattern](https://en.wikipedia.org/wiki/Observer_pattern). The Publish-Subscribe pattern builds on the Observer pattern by decoupling subjects from observers via asynchronous messaging.
 
 - [Message Broker Pattern](https://en.wikipedia.org/wiki/Message_broker). Many messaging subsystems that support a publish-subscribe model are implemented via a message broker.
+
+- [Publish/Subscribe sample](https://docs.particular.net/samples/pubsub/) using [NServiceBus](https://docs.particular.net/nservicebus/), showing how to leverage the Publisher/Subscriber pattern using a programming model that can be used with Azure Service Bus or other message broker technology.


### PR DESCRIPTION
Adding the NServiceBus Publish/Subscribe sample to the Publisher/Subscriber architecture doc gives a hands-on demonstration of the pattern to accompany the theoretical docs.