### PR TITLE
Remove a stray mdash, which was broken due to a missing semi-colon

### DIFF
--- a/docs/reference-architectures/enterprise-integration/basic-enterprise-integration.md
+++ b/docs/reference-architectures/enterprise-integration/basic-enterprise-integration.md
@@ -51,7 +51,7 @@ Your specific requirements might differ from the generic architecture shown here
 
 Use the API Management Basic, Standard, or Premium tiers. These tiers offer a production service level agreement (SLA) and support scale out within the Azure region. Throughput capacity for API Management is measured in *units*. Each pricing tier has a maximum scale-out. The Premium tier also supports scale out across multiple Azure regions. Choose your tier based on your feature set and the level of required throughput. For more information, see [API Management pricing][apim-pricing] and [Capacity of an Azure API Management instance][apim-capacity].
 
-Each Azure API Management instance has a default domain name, which is a subdomain of `azure-api.net` &mdash, for example, `contoso.azure-api.net`. Consider configuring a [custom domain][apim-domain] for your organization.
+Each Azure API Management instance has a default domain name, which is a subdomain of `azure-api.net`, for example, `contoso.azure-api.net`. Consider configuring a [custom domain][apim-domain] for your organization.
 
 ### Logic Apps
 


### PR DESCRIPTION
Fixing the mdash entity reference looked ugly, so opted to remove the whole entry instead.