### PR TITLE
Remove unnecessary commas

### DIFF
--- a/docs/guide/technology-choices/messaging.md
+++ b/docs/guide/technology-choices/messaging.md
@@ -23,7 +23,7 @@ Messages can be classified into two main categories. If the producer expects an 
 ## Commands
 The producer sends a command with the intent that the consumer(s) will perform an operation within the scope of a business transaction.
 
-A command is a high-value message and must be delivered at least once. If a command is lost, the entire business transaction might fail. Also, a command shouldn't be processed more than once. Doing so might cause an erroneous transaction. A customer might get duplicate orders or billed twice. 
+A command is a high-value message and must be delivered at least once. If a command is lost the entire business transaction might fail. Also, a command shouldn't be processed more than once. Doing so might cause an erroneous transaction. A customer might get duplicate orders or billed twice. 
 
 Commands are often used to manage the workflow of a multistep business transaction. Depending on the business logic, the producer may expect the consumer to acknowledge the message and report the results of the operation. Based on that result, the producer may choose an appropriate course of action. 
 
@@ -34,11 +34,11 @@ The producer (known as the _publisher_ in this context) has no expectations that
 
 Interested consumer(s), can subscribe, listen for events, and take actions depending on their consumption scenario. Events can have multiple subscribers or no subscribers at all. Two different subscribers can react to an event with different actions and not be aware of one another. 
 
-The producer and consumer are loosely coupled and managed independently. The consumer isn't expected to acknowledge the event back to the producer. A consumer that is no longer interested in the events, can unsubscribe. The consumer is removed from the pipeline without affecting the producer or the overall functionality of the system.
+The producer and consumer are loosely coupled and managed independently. The consumer isn't expected to acknowledge the event back to the producer. A consumer that is no longer interested in the events can unsubscribe. The consumer is removed from the pipeline without affecting the producer or the overall functionality of the system.
 
 There are two categories of events:
 
-- The producer raises events to announce discrete facts. A common use case is event  notification. For example, Azure Resource Manager raises events when it creates, modifies, or deletes resources. A subscriber of those events could be a Logic App that sends alert emails. 
+- The producer raises events to announce discrete facts. A common use case is event notification. For example, Azure Resource Manager raises events when it creates, modifies, or deletes resources. A subscriber of those events could be a Logic App that sends alert emails. 
 
 - The producer raises related events in a sequence, or a stream of events, over a period of time. Typically, a stream is consumed for statistical evaluation. The evaluation can be done within a temporal window or as events arrive. Telemetry is a common use case, for example, health and load monitoring of a system. Another case is event streaming from IoT devices. 
 


### PR DESCRIPTION
Removed a pair of unnecessary commas and a double space.

Comma changes:

> If a command is lost, the entire business transaction might fail.
> A consumer that is no longer interested in the events, can unsubscribe.

Changed to:

> If a command is lost the entire business transaction might fail.
> A consumer that is no longer interested in the events can unsubscribe.

Both of these sentences are single statements and in my opinion should not be broken up by a comma.