### PR TITLE
Update reference to 'nginScript' to use new name

### DIFF
--- a/docs/microservices/design/gateway.md
+++ b/docs/microservices/design/gateway.md
@@ -54,7 +54,7 @@ Here are some examples of functionality that could be offloaded to a gateway:
 
 Here are some options for implementing an API gateway in your application.
 
-- **Reverse proxy server**. Nginx and HAProxy are popular reverse proxy servers that support features such as load balancing, SSL, and layer 7 routing. They are both free, open-source products, with paid editions that provide additional features and support options. Nginx and HAProxy are both mature products with rich feature sets and high performance. You can extend them with third-party modules or by writing custom scripts in Lua. Nginx also supports a JavaScript-based scripting module called NginScript.
+- **Reverse proxy server**. Nginx and HAProxy are popular reverse proxy servers that support features such as load balancing, SSL, and layer 7 routing. They are both free, open-source products, with paid editions that provide additional features and support options. Nginx and HAProxy are both mature products with rich feature sets and high performance. You can extend them with third-party modules or by writing custom scripts in Lua. Nginx also supports a JavaScript-based scripting module referred to as '[NGINX JavaScript](https://www.nginx.com/blog/introduction-nginscript/)'. This module was formally named nginScript.
 
 - **Service mesh ingress controller**. If you are using a service mesh such as linkerd or Istio, consider the features that are provided by the ingress controller for that service mesh. For example, the Istio ingress controller supports layer 7 routing, HTTP redirects, retries, and other features.
 


### PR DESCRIPTION
'nginScript' module is now named, 'NGINX JavaScript'.