### PR TITLE
Removed duplicate sections

### DIFF
--- a/docs/guide/technology-choices/compute-decision-tree.md
+++ b/docs/guide/technology-choices/compute-decision-tree.md
@@ -136,30 +136,6 @@ For guided learning on Service Guarantees, review [Core Cloud Services - Azure a
 
 The output from this flowchart is a **starting point** for consideration. Next, perform a more detailed evaluation of the service to see if it meets your needs. 
 
-## Understand the basic features
-
-If you're not familiar with the Azure service selected in the previous step, read one of the following overview articles:
-
-- [App Service](/azure/app-service/)
-- [Azure Kubernetes Service](/azure/aks/intro-kubernetes)
-- [Batch](/azure/batch/batch-technical-overview)
-- [Container Instances](/azure/container-instances/container-instances-overview)
-- [Functions](/azure/azure-functions/functions-overview)
-- [Service Fabric](/azure/service-fabric/service-fabric-overview)
-- [Virtual machines](/azure/virtual-machines/)
-
-## Consider limits and cost
-
-Next, perform a more detailed evaluation, looking at the following aspects of the service:
-
-- [Service limits](/azure/azure-subscription-service-limits)
-- [Cost](https://azure.microsoft.com/pricing/)
-- [SLA](https://azure.microsoft.com/support/legal/sla/)
-- [Regional availability](https://azure.microsoft.com/global-infrastructure/services/)
-- [Compute comparison tables](./compute-comparison.md)
-
-Based on this analysis, you may find that the initial candidate isn't suitable for your particular application or workload. In that case, expand your analysis to include other compute services. 
-
 ## Next steps
 
 - [Core Cloud Services - Azure compute options](/learn/modules/intro-to-azure-compute/). This Microsoft Learn module explores how compute services can solve common business needs. 


### PR DESCRIPTION
The paragraphs with the title "Understand the basic features" and "Consider limits and cost" appeared twice on the page with the exact same content. Kept the first appearances that fit better in the section order.