### PR TITLE
outdated information

### DIFF
--- a/docs/aws-professional/index.md
+++ b/docs/aws-professional/index.md
@@ -127,7 +127,7 @@ The following table summarizes each option.
 
 ### Availability sets
 
-To protect against localized hardware failures, such as a disk or network switch failing, deploy two or more VMs in an availability set. An availability set consists of two or more *fault domains* that share a common power source and network switch. VMs in an availability set are distributed across the fault domains, so if a hardware failure affects one fault domain, network traffic can still be routed the VMs in the other fault domains. For more information about Availability Sets, see [Manage the availability of Windows virtual machines in Azure](https://docs.microsoft.com/azure/virtual-machines/windows/manage-availability).
+To protect against localized hardware failures, such as a disk or network switch failing, deploy two or more VMs in an availability set. An availability set consists of two or more *fault domains* that share a common power source and network switch. VMs in an availability set are distributed across the fault domains, so if a hardware failure affects one fault domain, network traffic can still be routed to the VMs in the other fault domains. For more information about Availability Sets, see [Manage the availability of Windows virtual machines in Azure](https://docs.microsoft.com/azure/virtual-machines/windows/manage-availability).
 
 When VM instances are added to availability sets, they are also assigned an [update domain](https://azure.microsoft.com/documentation/articles/virtual-machines-linux-manage-availability). An update domain is a group of VMs that are set for planned maintenance events at the same time. Distributing VMs across multiple update domains ensures that planned update and patching events affect only a subset of these VMs at any given time.
 
@@ -207,13 +207,13 @@ Autoscaling in Azure is handled by two services:
 
 The [Azure Kubernetes Service](https://docs.microsoft.com/azure/aks/intro-kubernetes) supports Docker containers managed through Kubernetes.
 
-#### Other compute services
+#### Distributed Systems Platform
 
-Azure offers several compute services that do not have direct equivalents in AWS:
+[Service Fabric](https://docs.microsoft.com/azure/service-fabric/service-fabric-overview) is a platform for developing and hosting scalable [microservices-based](https://docs.microsoft.com/azure/service-fabric/service-fabric-overview-microservices) solutions.
 
-- [Azure Batch](https://docs.microsoft.com/azure/batch/batch-technical-overview) allows you to manage compute-intensive work across a scalable collection of virtual machines.
+#### Batch Processing
 
-- [Service Fabric](https://docs.microsoft.com/azure/service-fabric/service-fabric-overview) is a platform for developing and hosting scalable [microservices-based](https://docs.microsoft.com/azure/service-fabric/service-fabric-overview-microservices) solutions.
+[Azure Batch](https://docs.microsoft.com/azure/batch/batch-technical-overview) allows you to manage compute-intensive work across a scalable collection of virtual machines.
 
 #### See also
 

--- a/docs/aws-professional/index.md
+++ b/docs/aws-professional/index.md
@@ -2,7 +2,7 @@
 title: Azure for AWS professionals
 description: Understand the basics of Microsoft Azure accounts, platform, and services. Also learn key similarities and differences between the AWS and Azure platforms. Take advantage of your AWS experience in Azure.
 keywords: AWS experts, Azure comparison, AWS comparison, difference between Azure and AWS, Azure and AWS
-author: author
+author: doodlemania2
 ms.date: 03/15/2020
 ms.topic: reference
 ms.service: architecture-center


### PR DESCRIPTION
This page has information that does not correspond to https://docs.microsoft.com/en-us/azure/architecture/aws-professional/services as AWS Batch and Azure Batch are comparable technologies and AWS App Mesh is comparable to Azure Service Fabric.

Note, not sure why github detecting the Availability Sets paragraph as being removed and deleted. Odd behavior.