### PR TITLE
Wrong url for resource limits sample

### DIFF
--- a/docs/framework/devops/app-design.md
+++ b/docs/framework/devops/app-design.md
@@ -34,7 +34,7 @@ Azure Resource Manager (ARM) enforces limits and quotas on how many resources of
 
 [Azure subscription and service limits, quotas, and constraints](https://docs.microsoft.com/azure/azure-subscription-service-limits#app-service-limits)
 
-![GitHub](../../_images/github.png) [This sample](https://github.com/mspnp/samples/tree/master/OperationalExcellenceResourceLimits) shows how to query limit and quotas for commonly used networking resources, virtual machines, SQL database, and storage accounts.
+![GitHub](../../_images/github.png) [This sample](https://github.com/mspnp/samples/tree/master/OperationalExcellence/ResourceLimits) shows how to query limit and quotas for commonly used networking resources, virtual machines, SQL database, and storage accounts.
 
 ## Tagging and resource naming
 


### PR DESCRIPTION
The url in line 37 is: https://github.com/mspnp/samples/tree/master/OperationalExcellenceResourceLimits

It should be: https://github.com/mspnp/samples/tree/master/OperationalExcellence/ResourceLimits