### PR TITLE
update deprecated 'group deployment' to 'deployment group'

### DIFF
--- a/docs/building-blocks/extending-templates/update-resource.md
+++ b/docs/building-blocks/extending-templates/update-resource.md
@@ -129,7 +129,7 @@ An example template is available on [GitHub][github]. To deploy the template, ru
 
 ```bash
 az group create --location <location> --name <resource-group-name>
-az group deployment create -g <resource-group-name> \
+az deployment group create -g <resource-group-name> \
     --template-uri https://raw.githubusercontent.com/mspnp/template-examples/master/example1-update/deploy.json
 ```
 


### PR DESCRIPTION
This command is implicitly deprecated because command group 'group deployment' is deprecated and will be removed in a future release. Use 'deployment group' instead.