### PR TITLE
Clarify App Service zonal support

### DIFF
--- a/docs/high-availability/building-solutions-for-high-availability.md
+++ b/docs/high-availability/building-solutions-for-high-availability.md
@@ -10,7 +10,7 @@ ms.category:
   - management-and-governance
   - solutions
 ms.subservice: reference-architecture
-ms.custom: high-availability
+ms.custom: high-availability,fasttrack-edit
 ---
 
 <!-- cSpell:ignore lbrader -->
@@ -177,7 +177,7 @@ services.
 
 - **Virtual machine scale sets (Z, ZR)**
 
-- **Azure App Service (Z)**
+- **Azure App Service environments (Z)**
 
 **Containers**
 


### PR DESCRIPTION
This PR clarifies that App Service only has zonal support for app service environments (ASEs) currently.