### PR TITLE
Add version note for Storage API examples in retry-service-specific.md

### DIFF
--- a/docs/best-practices/retry-service-specific.md
+++ b/docs/best-practices/retry-service-specific.md
@@ -873,6 +873,9 @@ Alternate retries switch between primary and secondary storage service location 
 
 ### Policy configuration
 
+> [!NOTE]
+> The examples below utilize **version 11** of the Azure Storage API.  We are tracking updates to utilize the latest version on our backlog.
+
 Retry policies are configured programmatically. A typical procedure is to create and populate a **TableRequestOptions**, **BlobRequestOptions**, **FileRequestOptions**, or **QueueRequestOptions** instance.
 
 ```csharp


### PR DESCRIPTION
Add a note to **best-practices/retry-service-specific.md** pointing out that Storage API examples are using version 11 of the Storage API and that updating the examples is on our backlog.

Fixes: #2302 