### PR TITLE
Add missing link for devops-monitoring

### DIFF
--- a/docs/reference-architectures/app-service-web-app/app-monitoring.md
+++ b/docs/reference-architectures/app-service-web-app/app-monitoring.md
@@ -167,3 +167,4 @@ Check out these resources designed to help you get started with your own monitor
 [app-insights-limits]: /azure/azure-subscription-service-limits#application-insights
 [message-filtering]: /azure/application-insights/app-insights-api-filtering-sampling
 [message-sampling]: /azure/application-insights/app-insights-sampling
+[devops-monitoring]: /azure/architecture/framework/devops/monitoring


### PR DESCRIPTION
Adds link to https://docs.microsoft.com/en-us/azure/architecture/framework/devops/monitoring