### PR TITLE
Update big-compute-with-azure-batch.md

### DIFF
--- a/docs/solution-ideas/articles/big-compute-with-azure-batch.md
+++ b/docs/solution-ideas/articles/big-compute-with-azure-batch.md
@@ -23,15 +23,12 @@ This solution implements a cloud-native application with Azure Batch, which prov
 
 This solution is built on managed services including Virtual Machines, Storage, and Batch. These Azure services run in a high-availability environment, patched and supported, allowing you to focus on your solution.
 
-The links to the right provide documentation on deploying and managing the Azure products listed in the solution architecture above.
+The links below provide documentation on deploying and managing the Azure products that are included in this solution idea:
 
-[Batch documentation](/azure/batch)
-
-[Virtual Machines](https://azure.microsoft.com/services/virtual-machines)
-
-[Azure Batch](https://azure.microsoft.com/services/batch)
-
-[Azure Blob Storage](https://azure.microsoft.com/services/storage)
+* [Batch documentation](/azure/batch)
+* [Virtual Machines](https://azure.microsoft.com/services/virtual-machines)
+* [Azure Batch](https://azure.microsoft.com/services/batch)
+* [Azure Blob Storage](https://azure.microsoft.com/services/storage)
 
 ## Architecture
 


### PR DESCRIPTION
The text was for how the content was presented as a Solution Architecture (on the services page). On this page, it needed tweaking.

It said, "The links to the right provide documentation on deploying and managing the Azure products listed in the solution architecture above."

1. The links were below the sentence, and they were no longer to the right of the sentence.
2. The architecture is arguably below the statement now (it was above the statement), as the "Architecture" section is below it (with the diagram), although the architecture is described above the statement. I changed this from "the Azure products listed in the solution architecture above" to "the Azure products that are included in this solution idea" instead.
3. I also changed the term "solution architecture" (old term for this content type) to "solution idea" (new term for this content type).
4. I added a colon at the end of this sentence (instead of a period), since it's setting up a set of four links, below it.
5. I turned the four links into bullets. It didn't make sense that each link was on a separate line (as a separate paragraph).