### PR TITLE
Event Hubs is also a pub/sub system and should be added to the publish/subscribe pattern doc

### DIFF
--- a/docs/patterns/publisher-subscriber.md
+++ b/docs/patterns/publisher-subscriber.md
@@ -62,7 +62,7 @@ Pub/sub messaging has the following benefits:
 
 Consider the following points when deciding how to implement this pattern:
 
-- **Existing technologies.** It is strongly recommended to use available messaging products and services that support a publish-subscribe model, rather than building your own. In Azure, consider using [Service Bus](/azure/service-bus-messaging/) or [Event Grid](/azure/event-grid/). Other technologies that can be used for pub/sub messaging include Redis, RabbitMQ, and Apache Kafka.
+- **Existing technologies.** It is strongly recommended to use available messaging products and services that support a publish-subscribe model, rather than building your own. In Azure, consider using [Service Bus](/azure/service-bus-messaging/), [Event Hubs](/azure/event-hubs/) or [Event Grid](/azure/event-grid/). Other technologies that can be used for pub/sub messaging include Redis, RabbitMQ, and Apache Kafka.
 
 - **Subscription handling.** The messaging infrastructure must provide mechanisms that consumers can use to subscribe to or unsubscribe from available channels.
 


### PR DESCRIPTION
Just noticed this while reading through the patterns docs for pub/sub - we mention Service Bus and Event Grid but I think EventHubs is also a pub/sub system. 

CC: @kevinlam1 since I believe Event Hubs is yours and I don't want to misstate EH's purpose :)