### PR TITLE
Update interservice-communication.md

### DIFF
--- a/docs/microservices/design/interservice-communication.md
+++ b/docs/microservices/design/interservice-communication.md
@@ -88,7 +88,7 @@ With these considerations in mind, the development team made the following desig
 
 - While a drone is in flight, the Drone service sends events that contain the drone's current location and status. The Delivery service listens to these events in order to track the status of a delivery.
 
-- When the status of a delivery changes, the Delivery service sends a delivery status event, such as `DeliveryCreated` or `DeliveryCompleted`. Any service can subscribe to these events. In the current design, the Delivery service is the only subscriber, but there might be other subscribers later. For example, the events might go to a real-time analytics service. And because the Scheduler doesn't have to wait for a response, adding more subscribers doesn't affect the main workflow path.
+- When the status of a delivery changes, the Delivery service sends a delivery status event, such as `DeliveryCreated` or `DeliveryCompleted`. Any service can subscribe to these events. In the current design, the Delivery History service is the only subscriber, but there might be other subscribers later. For example, the events might go to a real-time analytics service. And because the Scheduler doesn't have to wait for a response, adding more subscribers doesn't affect the main workflow path.
 
 ![Diagram of drone communication](../images/drone-communication.png)
 


### PR DESCRIPTION
Original text: "When the status of a delivery changes, the **Delivery service** sends a delivery status event, such as `DeliveryCreated` or `DeliveryCompleted`. Any service can subscribe to these events. In the current design, the **Delivery service** is the only subscriber".

Based on the diagram it is Delivery History service that subscribes to Delivery service events.