### PR TITLE
Add Azure Bastion as the jumpbox recommendation

### DIFF
--- a/docs/reference-architectures/n-tier/n-tier-sql-server-content.md
+++ b/docs/reference-architectures/n-tier/n-tier-sql-server-content.md
@@ -39,7 +39,7 @@ The architecture has the following components.
 
 - **Cloud Witness**. A failover cluster requires more than half of its nodes to be running, which is known as having quorum. If the cluster has just two nodes, a network partition could cause each node to think it's the primary node. In that case, you need a *witness* to break ties and establish quorum. A witness is a resource such as a shared disk that can act as a tie breaker to establish quorum. Cloud Witness is a type of witness that uses Azure Blob Storage. To learn more about the concept of quorum, see [Understanding cluster and pool quorum](/windows-server/storage/storage-spaces/understand-quorum). For more information about Cloud Witness, see [Deploy a Cloud Witness for a Failover Cluster](/windows-server/failover-clustering/deploy-cloud-witness).
 
-- **Jumpbox**. Also called a [bastion host]. Traditionally, a secure VM on the network that administrators use to connect to the other VMs. The jumpbox has an NSG that allows remote traffic only from public IP addresses on a safe list. The NSG should permit Remote Desktop Protocol (RDP) traffic. Azure offers the managed solution [Azure Bastion](/azure/bastion/) to meet this need.
+- **Jumpbox**. Also called a [bastion host]. Traditionally, a secure VM on the network that administrators use to connect to the other VMs. The jumpbox has an NSG that allows remote traffic only from public IP addresses on a safe list. The NSG should permit Remote Desktop Protocol (RDP) traffic. Azure offers the managed solution [Azure Bastion](/azure/bastion/bastion-overview) to meet this need.
 
 ## Recommendations
 

--- a/docs/reference-architectures/n-tier/n-tier-sql-server-content.md
+++ b/docs/reference-architectures/n-tier/n-tier-sql-server-content.md
@@ -39,7 +39,7 @@ The architecture has the following components.
 
 - **Cloud Witness**. A failover cluster requires more than half of its nodes to be running, which is known as having quorum. If the cluster has just two nodes, a network partition could cause each node to think it's the primary node. In that case, you need a *witness* to break ties and establish quorum. A witness is a resource such as a shared disk that can act as a tie breaker to establish quorum. Cloud Witness is a type of witness that uses Azure Blob Storage. To learn more about the concept of quorum, see [Understanding cluster and pool quorum](/windows-server/storage/storage-spaces/understand-quorum). For more information about Cloud Witness, see [Deploy a Cloud Witness for a Failover Cluster](/windows-server/failover-clustering/deploy-cloud-witness).
 
-- **Jumpbox**. Also called a [bastion host]. A secure VM on the network that administrators use to connect to the other VMs. The jumpbox has an NSG that allows remote traffic only from public IP addresses on a safe list. The NSG should permit remote desktop (RDP) traffic.
+- **Jumpbox**. Also called a [bastion host]. Traditionally. a secure VM on the network that administrators use to connect to the other VMs. The jumpbox has an NSG that allows remote traffic only from public IP addresses on a safe list. The NSG should permit remote desktop (RDP) traffic. Azure offers a managed solution known as [Azure Bastion](/azure/bastion/) that meets this need.
 
 ## Recommendations
 
@@ -107,11 +107,15 @@ Test your deployment by [forcing a manual failover][sql-alwayson-force-failover]
 
 ### Jumpbox
 
-Don't allow RDP access from the public Internet to the VMs that run the application workload. Instead, all RDP access to these VMs should go through the jumpbox. An administrator logs into the jumpbox, and then logs into the other VM from the jumpbox. The jumpbox allows RDP traffic from the Internet, but only from known, safe IP addresses.
+When running virtual machines in an private virtual network as in this architecture, there's a need to access virtual machines for software installation, patching, etc.  But, opening up access to these machines to the public Internet is not desireable, as it increases the attack surface significantly.  Instead, a jumpbox is used as a middle access layer.
 
-The jumpbox has minimal performance requirements, so select a small VM size. Create a [public IP address] for the jumpbox. Place the jumpbox in the same virtual network as the other VMs, but in a separate management subnet.
+In the past, a VM be used that is managed by the customer.  In this case, the following recommendations would apply:
 
-To secure the jumpbox, add an NSG rule that allows RDP connections only from a safe set of public IP addresses. Configure the NSGs for the other subnets to allow RDP traffic from the management subnet.
+- Don't allow RDP access from the public Internet to the VMs that run the application workload. Instead, all RDP access to these VMs should go through the jumpbox. An administrator logs into the jumpbox, and then logs into the other VM from the jumpbox. The jumpbox allows RDP traffic from the Internet, but only from known, safe IP addresses.
+- The jumpbox has minimal performance requirements, so select a small VM size. Create a [public IP address] for the jumpbox. Place the jumpbox in the same virtual network as the other VMs, but in a separate management subnet.
+- To secure the jumpbox, add an NSG rule that allows RDP connections only from a safe set of public IP addresses. Configure the NSGs for the other subnets to allow RDP traffic from the management subnet.
+
+For a customer-managed VM, all of these rules apply. However, the current recommendation is to use [Azure Bastion](/azure/bastion/), a managed jumpbox solution that allows for HTML5 access to RDP or SSH behind Azure AD protection.  This is a much simpler solution ultimately with a lower total cost of ownership (TCO) for the customer.
 
 ## Scalability considerations
 

--- a/docs/reference-architectures/n-tier/n-tier-sql-server-content.md
+++ b/docs/reference-architectures/n-tier/n-tier-sql-server-content.md
@@ -39,7 +39,7 @@ The architecture has the following components.
 
 - **Cloud Witness**. A failover cluster requires more than half of its nodes to be running, which is known as having quorum. If the cluster has just two nodes, a network partition could cause each node to think it's the primary node. In that case, you need a *witness* to break ties and establish quorum. A witness is a resource such as a shared disk that can act as a tie breaker to establish quorum. Cloud Witness is a type of witness that uses Azure Blob Storage. To learn more about the concept of quorum, see [Understanding cluster and pool quorum](/windows-server/storage/storage-spaces/understand-quorum). For more information about Cloud Witness, see [Deploy a Cloud Witness for a Failover Cluster](/windows-server/failover-clustering/deploy-cloud-witness).
 
-- **Jumpbox**. Also called a [bastion host]. Traditionally, a secure VM on the network that administrators use to connect to the other VMs. The jumpbox has an NSG that allows remote traffic only from public IP addresses on a safe list. The NSG should permit remote desktop (RDP) traffic. Azure offers the managed solution [Azure Bastion](/azure/bastion/) to meet this need.
+- **Jumpbox**. Also called a [bastion host]. Traditionally, a secure VM on the network that administrators use to connect to the other VMs. The jumpbox has an NSG that allows remote traffic only from public IP addresses on a safe list. The NSG should permit Remote Desktop Protocol (RDP) traffic. Azure offers the managed solution [Azure Bastion](/azure/bastion/) to meet this need.
 
 ## Recommendations
 
@@ -107,15 +107,15 @@ Test your deployment by [forcing a manual failover][sql-alwayson-force-failover]
 
 ### Jumpbox
 
-When running virtual machines in an private virtual network as in this architecture, there's a need to access virtual machines for software installation, patching, etc.  But, opening up access to these machines to the public Internet is not desireable, as it increases the attack surface significantly.  Instead, a jumpbox is used as a middle access layer.
+When you run virtual machines in a private virtual network, as in this architecture, there's a need to access virtual machines for software installation, patching, and so on.  But, making these machines accessible to the public internet isn't a good idea because it increases the attack surface significantly. Instead, a jumpbox is used as a middle access layer.
 
-In the past, a VM be used that is managed by the customer.  In this case, the following recommendations would apply:
+In the past, a VM that's managed by the customer might be used as a jumpbox.  In that scenario, the following recommendations apply:
 
-- Don't allow RDP access from the public Internet to the VMs that run the application workload. Instead, all RDP access to these VMs should go through the jumpbox. An administrator logs into the jumpbox, and then logs into the other VM from the jumpbox. The jumpbox allows RDP traffic from the Internet, but only from known, safe IP addresses.
+- Don't allow RDP access from the public internet to the VMs that run the application workload. Instead, all RDP access to these VMs should go through the jumpbox. An administrator logs in to the jumpbox and then logs in to the other VM from the jumpbox. The jumpbox allows RDP traffic from the internet, but only from known, safe IP addresses.
 - The jumpbox has minimal performance requirements, so select a small VM size. Create a [public IP address] for the jumpbox. Place the jumpbox in the same virtual network as the other VMs, but in a separate management subnet.
 - To secure the jumpbox, add an NSG rule that allows RDP connections only from a safe set of public IP addresses. Configure the NSGs for the other subnets to allow RDP traffic from the management subnet.
 
-For a customer-managed VM, all of these rules apply. However, the current recommendation is to use [Azure Bastion](/azure/bastion/), a managed jumpbox solution that allows for HTML5 access to RDP or SSH behind Azure AD protection.  This is a much simpler solution ultimately with a lower total cost of ownership (TCO) for the customer.
+For a customer-managed VM, all these rules apply. However, the current recommendation is to use [Azure Bastion](/azure/bastion/), a managed jumpbox solution that allows for HTML5 access to RDP or SSH behind Azure AD protection. This is a much simpler solution that ultimately has a lower total cost of ownership (TCO) for the customer.
 
 ## Scalability considerations
 

--- a/docs/reference-architectures/n-tier/n-tier-sql-server-content.md
+++ b/docs/reference-architectures/n-tier/n-tier-sql-server-content.md
@@ -39,7 +39,7 @@ The architecture has the following components.
 
 - **Cloud Witness**. A failover cluster requires more than half of its nodes to be running, which is known as having quorum. If the cluster has just two nodes, a network partition could cause each node to think it's the primary node. In that case, you need a *witness* to break ties and establish quorum. A witness is a resource such as a shared disk that can act as a tie breaker to establish quorum. Cloud Witness is a type of witness that uses Azure Blob Storage. To learn more about the concept of quorum, see [Understanding cluster and pool quorum](/windows-server/storage/storage-spaces/understand-quorum). For more information about Cloud Witness, see [Deploy a Cloud Witness for a Failover Cluster](/windows-server/failover-clustering/deploy-cloud-witness).
 
-- **Jumpbox**. Also called a [bastion host]. Traditionally. a secure VM on the network that administrators use to connect to the other VMs. The jumpbox has an NSG that allows remote traffic only from public IP addresses on a safe list. The NSG should permit remote desktop (RDP) traffic. Azure offers a managed solution known as [Azure Bastion](/azure/bastion/) that meets this need.
+- **Jumpbox**. Also called a [bastion host]. Traditionally, a secure VM on the network that administrators use to connect to the other VMs. The jumpbox has an NSG that allows remote traffic only from public IP addresses on a safe list. The NSG should permit remote desktop (RDP) traffic. Azure offers the managed solution [Azure Bastion](/azure/bastion/) to meet this need.
 
 ## Recommendations
 

--- a/docs/reference-architectures/n-tier/n-tier-sql-server-content.md
+++ b/docs/reference-architectures/n-tier/n-tier-sql-server-content.md
@@ -115,7 +115,7 @@ In the past, a VM that's managed by the customer might be used as a jumpbox. In 
 - The jumpbox has minimal performance requirements, so select a small VM size. Create a [public IP address] for the jumpbox. Place the jumpbox in the same virtual network as the other VMs, but in a separate management subnet.
 - To secure the jumpbox, add an NSG rule that allows RDP connections only from a safe set of public IP addresses. Configure the NSGs for the other subnets to allow RDP traffic from the management subnet.
 
-For a customer-managed VM, all these rules apply. However, the current recommendation is to use [Azure Bastion](/azure/bastion/), a managed jumpbox solution that allows for HTML5 access to RDP or SSH behind Azure AD protection. This is a much simpler solution that ultimately has a lower total cost of ownership (TCO) for the customer.
+For a customer-managed VM, all these rules apply. However, the current recommendation is to use [Azure Bastion](/azure/bastion/bastion-overview), a managed jumpbox solution that allows for HTML5 access to RDP or SSH behind Azure AD protection. This is a much simpler solution that ultimately has a lower total cost of ownership (TCO) for the customer.
 
 ## Scalability considerations
 

--- a/docs/reference-architectures/n-tier/n-tier-sql-server-content.md
+++ b/docs/reference-architectures/n-tier/n-tier-sql-server-content.md
@@ -107,9 +107,9 @@ Test your deployment by [forcing a manual failover][sql-alwayson-force-failover]
 
 ### Jumpbox
 
-When you run virtual machines in a private virtual network, as in this architecture, there's a need to access virtual machines for software installation, patching, and so on.  But, making these machines accessible to the public internet isn't a good idea because it increases the attack surface significantly. Instead, a jumpbox is used as a middle access layer.
+When you run virtual machines in a private virtual network, as in this architecture, there's a need to access virtual machines for software installation, patching, and so on. But, making these machines accessible to the public internet isn't a good idea because it increases the attack surface significantly. Instead, a jumpbox is used as a middle access layer.
 
-In the past, a VM that's managed by the customer might be used as a jumpbox.  In that scenario, the following recommendations apply:
+In the past, a VM that's managed by the customer might be used as a jumpbox. In that scenario, the following recommendations apply:
 
 - Don't allow RDP access from the public internet to the VMs that run the application workload. Instead, all RDP access to these VMs should go through the jumpbox. An administrator logs in to the jumpbox and then logs in to the other VM from the jumpbox. The jumpbox allows RDP traffic from the internet, but only from known, safe IP addresses.
 - The jumpbox has minimal performance requirements, so select a small VM size. Create a [public IP address] for the jumpbox. Place the jumpbox in the same virtual network as the other VMs, but in a separate management subnet.


### PR DESCRIPTION
The traditional VM-based jumpbox is no longer recommended; Azure Bastion is recommended.  Some of the other architectures eg https://docs.microsoft.com/en-us/azure/architecture/reference-architectures/dmz/secure-vnet-dmz?tabs=portal are already there.

This PR keeps the information on how to secure a traditional VM jumpbox but adds Azure Bastion as well.  A reasonable alternative would be to remove all references to a traditional jumpbox VM but I didn't know if we wanted to lose that security information here so I kept it for now.