### PR TITLE
removing link to dev spaces for vscode

### DIFF
--- a/docs/framework/devops/release-engineering-app-dev.md
+++ b/docs/framework/devops/release-engineering-app-dev.md
@@ -61,7 +61,7 @@ Some features of Bridge:
 
 **Learn more**
 
-- [Documentation: Use Bridge to Kubernetes with Visual Studio Code](/azure/dev-spaces/how-vs-code-works-with-dev-spaces)
+- [Documentation: Use Bridge to Kubernetes with Visual Studio Code](https://code.visualstudio.com/docs/containers/bridge-to-kubernetes)
 - [Documentation: Use Bridge to Kubernetes with Visual Studio](/visualstudio/containers/bridge-to-kubernetes?preserve-view=true&view=vs-2019)
 
 ### Other tools


### PR DESCRIPTION
updated link for VSCode to point directly to Bridge to Kubernetes docs.  It had been pointing to info on Dev Spaces, which is deprecated.