### PR TITLE
Update index.md

### DIFF
--- a/docs/gcp-professional/index.md
+++ b/docs/gcp-professional/index.md
@@ -57,7 +57,9 @@ Subscriptions are assigned three types of administrator accounts:
 - **Service Administrator**. This account has rights to create and manage resources in the subscription but is not responsible for billing. By default, the account administrator and service administrator are assigned to the same account. The account administrator can assign a separate user to the service administrator account for managing the technical and operational aspects of a subscription. Only one service administrator is assigned per subscription.
 - **Co-administrator**. There can be multiple co-administrator accounts assigned to a subscription. Co-administrators cannot change the service administrator, but otherwise have full control over subscription resources and users.
 
-Below the subscription level user roles and individual permissions can also be assigned to specific resources. In Azure, all user accounts are associated with either a Microsoft Account or Organizational Account (an account managed through an Azure Active Directory).
+For a fine-grained access management to Azure resources, you can use Azure role-based access control ([Azure RBAC](https://docs.microsoft.com/en-us/azure/role-based-access-control/rbac-and-directory-admin-roles)), that includes over 70 built-in roles. You can also create your own custom roles.
+
+In Azure, all user accounts are associated with either a Microsoft Account or Organizational Account (an account managed through an Azure Active Directory).
 
 Subscriptions have default service quotas and limits. For a full list of these limits, see [Azure subscription and service limits, quotas, and constraints](/azure/azure-subscription-service-limits). These limits can be increased up to the maximum by [filing a support request in the management portal](/archive/blogs/girishp/increasing-core-quota-limits-in-azure).
 

--- a/docs/gcp-professional/index.md
+++ b/docs/gcp-professional/index.md
@@ -57,7 +57,7 @@ Subscriptions are assigned three types of administrator accounts:
 - **Service Administrator**. This account has rights to create and manage resources in the subscription but is not responsible for billing. By default, the account administrator and service administrator are assigned to the same account. The account administrator can assign a separate user to the service administrator account for managing the technical and operational aspects of a subscription. Only one service administrator is assigned per subscription.
 - **Co-administrator**. There can be multiple co-administrator accounts assigned to a subscription. Co-administrators cannot change the service administrator, but otherwise have full control over subscription resources and users.
 
-For fine-grained access management to Azure resources, you can use Azure role-based access control ([Azure RBAC](https://docs.microsoft.com/azure/role-based-access-control/rbac-and-directory-admin-roles)), which includes over 70 built-in roles. You can also create your own custom roles.
+For fine-grained access management to Azure resources, you can use Azure role-based access control ([Azure RBAC](/azure/role-based-access-control/rbac-and-directory-admin-roles)), which includes over 70 built-in roles. You can also create your own custom roles.
 
 In Azure, all user accounts are associated with either a Microsoft Account or Organizational Account (an account managed through an Azure Active Directory).
 

--- a/docs/gcp-professional/index.md
+++ b/docs/gcp-professional/index.md
@@ -57,7 +57,7 @@ Subscriptions are assigned three types of administrator accounts:
 - **Service Administrator**. This account has rights to create and manage resources in the subscription but is not responsible for billing. By default, the account administrator and service administrator are assigned to the same account. The account administrator can assign a separate user to the service administrator account for managing the technical and operational aspects of a subscription. Only one service administrator is assigned per subscription.
 - **Co-administrator**. There can be multiple co-administrator accounts assigned to a subscription. Co-administrators cannot change the service administrator, but otherwise have full control over subscription resources and users.
 
-For a fine-grained access management to Azure resources, you can use Azure role-based access control ([Azure RBAC](https://docs.microsoft.com/en-us/azure/role-based-access-control/rbac-and-directory-admin-roles)), that includes over 70 built-in roles. You can also create your own custom roles.
+For fine-grained access management to Azure resources, you can use Azure role-based access control ([Azure RBAC](https://docs.microsoft.com/azure/role-based-access-control/rbac-and-directory-admin-roles)), which includes over 70 built-in roles. You can also create your own custom roles.
 
 In Azure, all user accounts are associated with either a Microsoft Account or Organizational Account (an account managed through an Azure Active Directory).
 


### PR DESCRIPTION
Added information about Azure RBAC, as currently we have only classic subscription administrator roles listed. Also removed inaccurate statement about assignment of individual permissions - we add permissions to roles and then assign the roles to end users in Azure, not individual permissions.