### PR TITLE
Move up instance IP note

### DIFF
--- a/docs/example-scenario/gateway/firewall-application-gateway-content.md
+++ b/docs/example-scenario/gateway/firewall-application-gateway-content.md
@@ -57,7 +57,8 @@ The following packet walk example shows how a client accesses a VM-hosted applic
 In this design, Azure Firewall inspects both incoming connections from the public internet, and outbound connections from the application subnet VM by using the UDR.
    - Azure Firewall service deploys several instances under the covers, here with the front-end IP address 192.168.100.4 and internal addresses from the range 192.168.100.0/24.  These individual instances are normally invisible to the Azure administrator.  But noticing the difference is useful in some cases, such as when troubleshooting network issues. 
    - If traffic comes from an on-premises virtual private network (VPN) or [Azure ExpressRoute][expressroute] gateway instead of the internet, the client starts the connection to the VM's IP address. It doesn't start the connection to the firewall's IP address, and the firewall will do no Source NAT per default.
-   - The traffic flow assuming the instance IP address `192.168.100.7` is the following
+ 
+The following diagram shows the traffic flow assuming the instance IP address is `192.168.100.7`.
 
 
 ![Firewall only](./images/design1_500.png)

--- a/docs/example-scenario/gateway/firewall-application-gateway-content.md
+++ b/docs/example-scenario/gateway/firewall-application-gateway-content.md
@@ -54,6 +54,11 @@ Azure Firewall won't inspect inbound HTTP(S) traffic. But it will be able to app
 - Azure Firewall Premium will add capabilities such as inspecting other HTTP headers (such as the User-Agent) and enabling TLS inspection for deeper packet analysis. Azure Firewall isn't equivalent to a Web Application Firewall. If you have web workloads in your Virtual Network, using WAF is highly recommended.
 
 The following packet walk example shows how a client accesses a VM-hosted application from the public internet. The diagram includes only one VM for simplicity. For higher availability and scalability, you'd have multiple application instances behind a load balancer.
+In this design, Azure Firewall inspects both incoming connections from the public internet, and outbound connections from the application subnet VM by using the UDR.
+   - Azure Firewall service deploys several instances under the covers, here with the front-end IP address 192.168.100.4 and internal addresses from the range 192.168.100.0/24.  These individual instances are normally invisible to the Azure administrator.  But noticing the difference is useful in some cases, such as when troubleshooting network issues. 
+   - If traffic comes from an on-premises virtual private network (VPN) or [Azure ExpressRoute][expressroute] gateway instead of the internet, the client starts the connection to the VM's IP address. It doesn't start the connection to the firewall's IP address, and the firewall will do no Source NAT per default.
+   - The traffic flow assuming the instance IP address `192.168.100.7` is the following
+
 
 ![Firewall only](./images/design1_500.png)
 
@@ -70,11 +75,6 @@ The following packet walk example shows how a client accesses a VM-hosted applic
    - Source IP address: AzFwPIP
    - Destination IP address: ClientPIP
 
-In this design, Azure Firewall inspects both incoming connections from the public internet, and outbound connections from the application subnet VM by using the UDR.
-
-- The IP address `192.168.100.7` is one of the instances the Azure Firewall service deploys under the covers, here with the front-end IP address `192.168.100.4`. These individual instances are normally invisible to the Azure administrator. But noticing the difference is useful in some cases, such as when troubleshooting network issues.
-
-- If traffic comes from an on-premises virtual private network (VPN) or [Azure ExpressRoute][expressroute] gateway instead of the internet, the client starts the connection to the VM's IP address. It doesn't start the connection to the firewall's IP address, and the firewall will do no Source NAT per default.
 
 ## Application Gateway only
 


### PR DESCRIPTION
The note about instances under the cover with internal IP could be moved before the traffic flow explanation in order to better understanding of the flow and not lead to confusion about an IP value that doesn't appear in the diagram