### PR TITLE
Align HTTP status code in description to diagram

### DIFF
--- a/docs/patterns/async-request-reply-content.md
+++ b/docs/patterns/async-request-reply-content.md
@@ -45,7 +45,7 @@ The following diagram shows a typical flow:
 ![Request and response flow for asynchronous HTTP requests](./_images/async-request.png)
 
 1. The client sends a request and receives an HTTP 202 (Accepted) response.
-2. The client sends an HTTP GET request to the status endpoint. The work is still pending, so this call returns HTTP 202.
+2. The client sends an HTTP GET request to the status endpoint. The work is still pending, so this call returns HTTP 200.
 3. At some point, the work is complete and the status endpoint returns 302 (Found) redirecting to the resource.
 4. The client fetches the resource at the specified URL.
 


### PR DESCRIPTION
In the solutions sequence diagram the first call to the status endpoint returns 200. The second point of the description following description mentions a 202. Those two things should be aligned.