### PR TITLE
Update cloud-scale-analytics-with-discovery-hub.yml

### DIFF
--- a/docs/solution-ideas/articles/cloud-scale-analytics-with-discovery-hub.yml
+++ b/docs/solution-ideas/articles/cloud-scale-analytics-with-discovery-hub.yml
@@ -4,8 +4,8 @@ metadata:
   titleSuffix: Azure Solution Ideas
   description: Use TimeXtender to build a modern data estate that is ready for cloud scale analytics using a drag-and-drop user interface, with definitions stored in a metadata repository.
   author: EdPrice-MSFT
-  ms.author: pnp
-  ms.date: 12/16/2019
+  ms.author: edprice
+  ms.date: 05/19/2022
   ms.topic: conceptual
   ms.service: architecture-center
   ms.subservice: solution-idea
@@ -20,7 +20,7 @@ metadata:
     - interactive-diagram
     - "https://azure.microsoft.com/solutions/architecture/cloud-scale-analytics-with-discovery-hub/"
   social_image_url: /azure/architecture/solution-ideas/articles/media/cloud-scale-analytics-with-discovery-hub.png
-name: Discovery Hub with cloud scale analytics
+name: TimeXtender with cloud scale analytics
 azureCategories:
   - analytics
   - databases

--- a/docs/solution-ideas/articles/cloud-scale-analytics-with-discovery-hub.yml
+++ b/docs/solution-ideas/articles/cloud-scale-analytics-with-discovery-hub.yml
@@ -1,8 +1,8 @@
 ### YamlMime:Architecture
 metadata:
-  title: Discovery Hub with cloud scale analytics
+  title: Cloud scale analytics with TimeXtender
   titleSuffix: Azure Solution Ideas
-  description: Use Discovery Hub to define a modern data estate that is ready for cloud scale analytics using a graphical user interface, with definitions stored in a metadata repository.
+  description: Use TimeXtender to build a modern data estate that is ready for cloud scale analytics using a drag-and-drop user interface, with definitions stored in a metadata repository.
   author: EdPrice-MSFT
   ms.author: pnp
   ms.date: 12/16/2019
@@ -24,7 +24,7 @@ name: Discovery Hub with cloud scale analytics
 azureCategories:
   - analytics
   - databases
-summary: Use Discovery Hub to define a modern data estate that is ready for cloud scale analytics using a graphical user interface, with definitions stored in a metadata repository.
+summary: Use TimeXtender to build a modern data estate that is ready for cloud scale analytics using a drag-and-drop user interface, with definitions stored in a metadata repository.
 products:
   - azure-analysis-services
   - azure-data-lake-storage


### PR DESCRIPTION
We no longer call it "Discovery Hub". Just TimeXtender.