### PR TITLE
Multiple VWAN Hubs in same region is available

### DIFF
--- a/docs/networking/hub-spoke-vwan-architecture-content.md
+++ b/docs/networking/hub-spoke-vwan-architecture-content.md
@@ -164,7 +164,7 @@ Connectivity among spokes is already achieved using Azure Virtual WAN. However, 
 
 Virtual network peering is a nontransitive relationship between two virtual networks. While using Azure Virtual WAN, virtual network peering is managed by Microsoft. Each connection added to a hub will also configure virtual network peering. With the help Virtual WAN, all spokes will have a transitive relationship.
 
-## Pricing
+### Cost optimization
 
 A customer-managed hub infrastructure introduces management cost to underlying Azure resources. To achieve a transitive connectivity with a predictable latency, you must have a Network Virtual Appliance (NVA) or Azure Firewall deployed in each hub. Using Azure Firewall with either choice will lower the cost compared to an NVA. Azure Firewall costs are the same for both options. There is an extra cost for Azure Virtual WAN; however, it is much less costly than managing your own hub infrastructure.
 

--- a/docs/networking/hub-spoke-vwan-architecture-content.md
+++ b/docs/networking/hub-spoke-vwan-architecture-content.md
@@ -97,7 +97,9 @@ Standard Virtual WANs are by default connected in a full mesh. Standard Virtual 
 
 ### Virtual WAN Hub
 
-A virtual hub is a Microsoft-managed virtual network. The hub contains various service endpoints to enable connectivity. The hub is the core of your network in a region. There can be multiple hubs per Azure region (see [Virtual WAN FAQ](https://docs.microsoft.com/en-us/azure/virtual-wan/virtual-wan-faq#is-it-possible-to-create-multiple-virtual-wan-hubs-in-the-same-region)). When you create a hub using the Azure portal, it creates a virtual hub VNet and a virtual hub VPN gateway. A Virtual WAN Hub requires an address range minimum of /24. This IP address space will be used for reserving a subnet for gateway and other components.
+A virtual hub is a Microsoft-managed virtual network. The hub contains various service endpoints to enable connectivity. The hub is the core of your network in a region. There can be multiple hubs per Azure region. For more information, see [Virtual WAN FAQ](/azure/virtual-wan/virtual-wan-faq#is-it-possible-to-create-multiple-virtual-wan-hubs-in-the-same-region). 
+
+When you create a hub using the Azure portal, it creates a virtual hub VNet and a virtual hub VPN gateway. A Virtual WAN Hub requires an address range minimum of /24. This IP address space will be used for reserving a subnet for gateway and other components.
 
 ### Secured virtual hub
 

--- a/docs/networking/hub-spoke-vwan-architecture-content.md
+++ b/docs/networking/hub-spoke-vwan-architecture-content.md
@@ -97,7 +97,7 @@ Standard Virtual WANs are by default connected in a full mesh. Standard Virtual 
 
 ### Virtual WAN Hub
 
-A virtual hub is a Microsoft-managed virtual network. The hub contains various service endpoints to enable connectivity. The hub is the core of your network in a region. There can only be one hub per Azure region. When you create a hub using the Azure portal, it creates a virtual hub VNet and a virtual hub VPN gateway. A Virtual WAN Hub requires an address range minimum of /24. This IP address space will be used for reserving a subnet for gateway and other components.
+A virtual hub is a Microsoft-managed virtual network. The hub contains various service endpoints to enable connectivity. The hub is the core of your network in a region. There can be multiple hubs per Azure region (see [Virtual WAN FAQ](https://docs.microsoft.com/en-us/azure/virtual-wan/virtual-wan-faq#is-it-possible-to-create-multiple-virtual-wan-hubs-in-the-same-region)). When you create a hub using the Azure portal, it creates a virtual hub VNet and a virtual hub VPN gateway. A Virtual WAN Hub requires an address range minimum of /24. This IP address space will be used for reserving a subnet for gateway and other components.
 
 ### Secured virtual hub
 


### PR DESCRIPTION
In the Virtual WAN Hub section, we currently this statement, "There can only be one hub per Azure region." Per the VWAN FAQ (https://docs.microsoft.com/en-us/azure/virtual-wan/virtual-wan-faq#is-it-possible-to-create-multiple-virtual-wan-hubs-in-the-same-region), we can now have multiple virtual hubs per region for the same VWAN. I have corrected the statement and added a link directly to the corresponding FAQ.