### PR TITLE
Add link to latency fallacy

### DIFF
--- a/docs/includes/microservices-intro.md
+++ b/docs/includes/microservices-intro.md
@@ -69,7 +69,7 @@ The benefits of microservices don't come for free. Here are some of the challeng
 
 - **Lack of governance**. The decentralized approach to building microservices has advantages, but it can also lead to problems. You may end up with so many different languages and frameworks that the application becomes hard to maintain. It may be useful to put some project-wide standards in place, without overly restricting teams' flexibility. This especially applies to cross-cutting functionality such as logging.
 
-- **Network congestion and latency**. The use of many small, granular services can result in more interservice communication. Also, if the chain of service dependencies gets too long (service A calls B, which calls C...), the additional latency can become a problem. You will need to design APIs carefully. Avoid overly chatty APIs, think about serialization formats, and look for places to use asynchronous communication patterns like [queue-based load leveling](../patterns/queue-based-load-leveling.yml).
+- **Network congestion and latency**. The use of many small, granular services can result in more interservice communication. Also, if the chain of service dependencies gets too long (service A calls B, which calls C...), the additional [latency can become a problem](https://particular.net/blog/latency-is-zero). You will need to design APIs carefully. Avoid overly chatty APIs, think about serialization formats, and look for places to use asynchronous communication patterns like [queue-based load leveling](../patterns/queue-based-load-leveling.yml).
 
 - **Data integrity**. With each microservice responsible for its own data persistence. As a result, data consistency can be a challenge. Embrace eventual consistency where possible.
 


### PR DESCRIPTION
This is a re-post of https://github.com/MicrosoftDocs/architecture-center/pull/3481 which was closed but I'd like it to be reconsidered. It's a link to a blog post on a well-known topic in distributed computing that I believe is directly relevant to the text in that it's backing up the claim that latency can become a problem. I also don't believe it's promotional as the discussion focuses solely on the concepts with most of the links going to further discussions on the fallacies of distributed computing. It's [not without precedent](https://github.com/MicrosoftDocs/architecture-center/pull/2639) on Microsoft's docs.