### PR TITLE
Update the heading to K8S upgrade (control plane)

### DIFF
--- a/docs/operator-guides/aks/aks-upgrade-practices.md
+++ b/docs/operator-guides/aks/aks-upgrade-practices.md
@@ -163,7 +163,7 @@ For information about validation rules for cluster upgrades, see [Validation rul
 
 The following table describes characteristics of various AKS upgrade and patching scenarios:
 
-|Scenario|User initiated|K8S upgrade|OS kernel upgrade|Node image upgrade|
+|Scenario|User initiated|K8S upgrade (control plane)|OS kernel upgrade|Node image upgrade|
 |--------|--------------|------------------|-----------------|------------------|-----|
 |Security patching | No  | No | Yes, following reboot | Yes  |
 |Cluster create | Yes  | Maybe | Yes, if an updated node image uses an updated kernel.|Yes, relative to an existing cluster if a new release is available.|


### PR DESCRIPTION
Hello,
Can we update one of the column names from 'K8S upgrade' to 'K8S upgrade (control plane)' for more clarity? This is for the scenarios table under the 'Considerations' section.
Regards, Saurabh