### PR TITLE
updating routing logic for azure spring apps

### DIFF
--- a/docs/guide/technology-choices/compute-decision-tree-content.md
+++ b/docs/guide/technology-choices/compute-decision-tree-content.md
@@ -6,8 +6,7 @@ If your application consists of multiple workloads, evaluate each workload separ
 
 Use the following flowchart to select a candidate compute service.
 
-![decision tree](https://user-images.githubusercontent.com/29985344/187650603-cb51c9f6-ef93-4099-9258-139889d3511f.png)
-
+![Decision tree for Azure compute services.](https://user-images.githubusercontent.com/29985344/187650603-cb51c9f6-ef93-4099-9258-139889d3511f.png)
 
 Definitions:
 

--- a/docs/guide/technology-choices/compute-decision-tree-content.md
+++ b/docs/guide/technology-choices/compute-decision-tree-content.md
@@ -6,7 +6,8 @@ If your application consists of multiple workloads, evaluate each workload separ
 
 Use the following flowchart to select a candidate compute service.
 
-![Decision tree for Azure compute services](images/compute-choices.png)
+![decision tree](https://user-images.githubusercontent.com/29985344/187650603-cb51c9f6-ef93-4099-9258-139889d3511f.png)
+
 
 Definitions:
 


### PR DESCRIPTION
At Microsoft Build this year we announced a product name change and Azure Spring Cloud is now Azure Spring Apps. The name change reflects new product capabilities and positioning for all types of Spring apps. In contrast, Azure Spring Apps was considered a niche product only for microservices when we first started. As such I would like to propose a change in the decision tree and route all types of Spring apps to Azure Spring Apps.