### PR TITLE
Remove misleading and inaccurate assertions

### DIFF
--- a/docs/example-scenario/iot/real-time-iot-updates-cloud-apps-content.md
+++ b/docs/example-scenario/iot/real-time-iot-updates-cloud-apps-content.md
@@ -57,7 +57,7 @@ Consider these points when you use this pattern:
 
 - Azure SignalR Service defines seven tiers that accommodate a range of performance capacities. Determine your scenario's inbound and outbound capacity by understanding the factors that affect these values. Then select the tier that best meets your requirements. For more information, see [Performance guide for Azure SignalR Service](/azure/azure-signalr/signalr-concept-performance).
 
-- Consider having your own message ACK mechanism when you need to guarantee message delivery when publishing messages to multiple clients. Azure SignalR builds upon SignalR protocol and follows publish-subscribe pattern when broadcasting messages to the clients.
+- Azure SignalR builds upon SignalR protocol and follows publish-subscribe pattern when broadcasting messages to multiple clients. Consider having your own message ACK mechanism when you need to guarantee message delivery in such scenario.
 
 - When you're displaying real-time data in Power BI visuals, consider [Real-time streaming in Power BI](/power-bi/connect-data/service-real-time-streaming) as an alternative to this solution.
 

--- a/docs/example-scenario/iot/real-time-iot-updates-cloud-apps-content.md
+++ b/docs/example-scenario/iot/real-time-iot-updates-cloud-apps-content.md
@@ -57,7 +57,7 @@ Consider these points when you use this pattern:
 
 - Azure SignalR Service defines seven tiers that accommodate a range of performance capacities. Determine your scenario's inbound and outbound capacity by understanding the factors that affect these values. Then select the tier that best meets your requirements. For more information, see [Performance guide for Azure SignalR Service](/azure/azure-signalr/signalr-concept-performance).
 
-- Consider having your own message ack mechanism when you need to guarantee message delivery. Azure SignalR builds upon SignalR protocol and follows publish-subscribe pattern when broadcasting messages to the clients.
+- Consider having your own message ACK mechanism when you need to guarantee message delivery when publishing messages to multiple clients. Azure SignalR builds upon SignalR protocol and follows publish-subscribe pattern when broadcasting messages to the clients.
 
 - When you're displaying real-time data in Power BI visuals, consider [Real-time streaming in Power BI](/power-bi/connect-data/service-real-time-streaming) as an alternative to this solution.
 

--- a/docs/example-scenario/iot/real-time-iot-updates-cloud-apps-content.md
+++ b/docs/example-scenario/iot/real-time-iot-updates-cloud-apps-content.md
@@ -57,7 +57,7 @@ Consider these points when you use this pattern:
 
 - Azure SignalR Service defines seven tiers that accommodate a range of performance capacities. Determine your scenario's inbound and outbound capacity by understanding the factors that affect these values. Then select the tier that best meets your requirements. For more information, see [Performance guide for Azure SignalR Service](/azure/azure-signalr/signalr-concept-performance).
 
-- Azure SignalR builds upon SignalR protocol and follows publish-subscribe pattern when broadcasting messages to multiple clients. Consider having your own message ACK mechanism when you need to guarantee message delivery in such scenario.
+- Azure SignalR builds upon SignalR protocol and follows publish-subscribe pattern when broadcasting messages to the clients. Consider having your own message ACK mechanism when you need to guarantee message delivery when publishing messages to multiple clients. 
 
 - When you're displaying real-time data in Power BI visuals, consider [Real-time streaming in Power BI](/power-bi/connect-data/service-real-time-streaming) as an alternative to this solution.
 

--- a/docs/example-scenario/iot/real-time-iot-updates-cloud-apps-content.md
+++ b/docs/example-scenario/iot/real-time-iot-updates-cloud-apps-content.md
@@ -57,7 +57,7 @@ Consider these points when you use this pattern:
 
 - Azure SignalR Service defines seven tiers that accommodate a range of performance capacities. Determine your scenario's inbound and outbound capacity by understanding the factors that affect these values. Then select the tier that best meets your requirements. For more information, see [Performance guide for Azure SignalR Service](/azure/azure-signalr/signalr-concept-performance).
 
-- Don't use this solution when you need to guarantee message delivery. Due to the variable nature of clients, Azure SignalR Service doesn't always provide business-critical reliability.
+- Consider having your own message ack mechanism when you need to guarantee message delivery. Azure SignalR builds upon SignalR protocol and follows publish-subscribe pattern when broadcasting messages to the clients.
 
 - When you're displaying real-time data in Power BI visuals, consider [Real-time streaming in Power BI](/power-bi/connect-data/service-real-time-streaming) as an alternative to this solution.
 


### PR DESCRIPTION
The assertion is pretty misleading and worries our customers. Azure SignalR service surely provides business-critical reliability, and customers could use ACK mechanism to guarantee delivery in their application layer.