### PR TITLE
Add link to Azure REST API Guidelines

### DIFF
--- a/docs/best-practices/api-design.md
+++ b/docs/best-practices/api-design.md
@@ -535,6 +535,8 @@ You may want to adopt OpenAPI for your web APIs. Some points to consider:
 
 - [Microsoft REST API guidelines](https://github.com/Microsoft/api-guidelines/blob/master/Guidelines.md). Detailed recommendations for designing public REST APIs.
 
+- [Azure REST API guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md). Design guidelines for Azure REST APIs.
+
 - [Web API checklist](https://mathieu.fenniak.net/the-api-checklist). A useful list of items to consider when designing and implementing a web API.
 
 - [Open API Initiative](https://www.openapis.org). Documentation and implementation details on Open API.


### PR DESCRIPTION
This tiny PR just adds a link to Azure's REST API Guidelines to the bottom of the page.