### PR TITLE
Include mention of Service Bus

### DIFF
--- a/docs/reference-architectures/containers/aks-mission-critical/mission-critical-app-platform.md
+++ b/docs/reference-architectures/containers/aks-mission-critical/mission-critical-app-platform.md
@@ -184,7 +184,7 @@ For other considerations on secret management, see [Misson-critical guidance in 
 
 ### Event Hubs
 
-As mentioned earlier, for use cases that require additional message guarantees, [Azure Service Bus](/azure/service-bus-messaging/) is recommended. It is reasonable for a given architecture to make use of both Azure Event Hubs and Azure Service Bus.
+As mentioned earlier, for use cases that require additional message guarantees, [Azure Service Bus](/azure/service-bus-messaging/) is recommended. It is reasonable for a given architecture to make use of both Azure Event Hubs and Azure Service Bus. See the [Design Considerations below](#design-considerations-4) for more guidance about which service to use for which use cases.
 
 The only stateful service in the stamp is the message broker, Azure Event Hubs, which stores requests for a short period. The broker serves the **need for buffering and reliable messaging**. The processed requests are persisted in the global database.
 

--- a/docs/reference-architectures/containers/aks-mission-critical/mission-critical-app-platform.md
+++ b/docs/reference-architectures/containers/aks-mission-critical/mission-critical-app-platform.md
@@ -184,6 +184,8 @@ For other considerations on secret management, see [Misson-critical guidance in 
 
 ### Event Hubs
 
+As mentioned earlier, for use cases that require additional message guarantees, [Azure Service Bus](/azure/service-bus-messaging/) is recommended. It is reasonable for a given architecture to make use of both Azure Event Hubs and Azure Service Bus.
+
 The only stateful service in the stamp is the message broker, Azure Event Hubs, which stores requests for a short period. The broker serves the **need for buffering and reliable messaging**. The processed requests are persisted in the global database.
 
 In this architecture, Standard SKU is used and zone redundancy is enabled for high availability.


### PR DESCRIPTION
The top-level guidance of the baseline architecture mentions Azure Service Bus as an option here:
https://learn.microsoft.com/en-us/azure/architecture/reference-architectures/containers/aks-mission-critical/mission-critical-intro#regional-message-broker

The Application Platform guidance didn't have any mention of it, so this PR brings that in.