### PR TITLE
typo: fixed typo in event-sourcing-content.md

### DIFF
--- a/docs/patterns/event-sourcing-content.md
+++ b/docs/patterns/event-sourcing-content.md
@@ -61,7 +61,7 @@ The length of each event stream affects managing and updating the system. If the
 
 Even though event sourcing minimizes the chance of conflicting updates to the data, the application must still be able to deal with inconsistencies that result from eventual consistency and the lack of transactions. For example, an event that indicates a reduction in stock inventory might arrive in the data store while an order for that item is being placed. This situation results in a requirement to reconcile the two operations, either by advising the customer or by creating a back order.
 
-Event publication might be _at least once_, and so consumers of the events must be idempotent. They must not reapply the update described in an event if the event is handled more than once. Multiple instances of a consumer cn maintain and aggregate an entity's property, such as the total number of orders placed. Only one must succeed in incrementing the aggregate, when an order-placed event occurs. While this result isn't a key characteristic of event sourcing, it's the usual implementation decision.
+Event publication might be _at least once_, and so consumers of the events must be idempotent. They must not reapply the update described in an event if the event is handled more than once. Multiple instances of a consumer can maintain and aggregate an entity's property, such as the total number of orders placed. Only one must succeed in incrementing the aggregate, when an order-placed event occurs. While this result isn't a key characteristic of event sourcing, it's the usual implementation decision.
 
 ## When to use this pattern
 


### PR DESCRIPTION
There was a tiny typo in the docs