### PR TITLE
Fixed typos in structured logging JSON

### DIFF
--- a/docs/example-scenario/logging/unified-logging-content.md
+++ b/docs/example-scenario/logging/unified-logging-content.md
@@ -139,13 +139,13 @@ The following code shows examples of the structured logging objects:
 
 ```json
 {
-  "CorrelationId": "715eec8f-fefc-45e2-a352-95aa389ddb8f"
+  "CorrelationId": "715eec8f-fefc-45e2-a352-95aa389ddb8f",
   "Environment": "Live",
-  "StatusCode: 500,
-  "Severity: "Error",
+  "StatusCode": 500,
+  "Severity": "Error",
   "Application": "Contso Web Shop",
   "Service": "PaymentsService",
-  "EventTimeUTC:" "2020-04-27T13:19Z",
+  "EventTimeUTC": "2020-04-27T13:19Z",
   "BrowserType": "Chromium",
   "Data":{
       "Runtime":"Net Core",


### PR DESCRIPTION
In "Structured logging" section of "Unified logging for microservices applications" article there is a snippet provided for structure logging object JSON output that has a few typos that result in an invalid JSON.  

I've updated those for consistency and in order for the snippet to represent a valid JSON to minimize confusion.