### PR TITLE
Update commands used for TS in troubleshoot-network-aks.md

### DIFF
--- a/docs/operator-guides/aks/troubleshoot-network-aks.md
+++ b/docs/operator-guides/aks/troubleshoot-network-aks.md
@@ -78,7 +78,7 @@ create pod sandbox: rpc error: code = Unknown desc = NetworkPlugin cni failed to
 delegate: Failed to allocate address: No available addresses 
 ```
 
-Another example of the error:
+Or a `not enough IPs available` error:
 
 ```output
 Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox 
@@ -94,7 +94,7 @@ a1231464635654a123646565456cc146841c1313546a515432161a45a5316541, OrchestratorCo
 
 Check the allocated IP addresses in the plugin IPAM store. You might find that all IP addresses are allocated, but the number is much less than the number of running Pods:
 
-**If using [`kubenet`](/azure/aks/configure-kubenet):**
+**If using [kubenet](/azure/aks/configure-kubenet):**
 
 ```bash
 # Kubenet, for example. The actual path of the IPAM store file depends on network plugin implementation. 
@@ -104,7 +104,7 @@ ls -la "/var/lib/cni/networks/$(ls /var/lib/cni/networks/ | grep -e "k8s-pod-net
 ```
 
 > [!NOTE]
-> For `kubenet` without `calico`, the path is `/var/lib/cni/networks/kubenet`. For `kubenet` with `calico`, the path is `/var/lib/cni/networks/k8s-pod-network`. In this demo, it will auto-select the path while executing the command.
+> For kubenet without Calico, the path is `/var/lib/cni/networks/kubenet`. For kubenet with Calico, the path is `/var/lib/cni/networks/k8s-pod-network`. The script above will auto select the path while executing the command.
 
 ```bash
 # Check running Pod IPs
@@ -112,15 +112,18 @@ kubectl get pods --field-selector spec.nodeName=<your_node_name>,status.phase=Ru
 7 
 ```
 
-**If using [`Azure CNI for dynamic IP allocation`](/azure/aks/configure-azure-cni-dynamic-ip-allocation):**
+**If using [Azure CNI for dynamic IP allocation](/azure/aks/configure-azure-cni-dynamic-ip-allocation):**
 
-```
+```bash
 kubectl get nnc -n kube-system -o wide
+```
+
+```output
 NAME                               REQUESTED IPS  ALLOCATED IPS  SUBNET  SUBNET CIDR   NC ID                                 NC MODE  NC TYPE  NC VERSION
 aks-agentpool-12345678-vmss000000  32             32             subnet  10.18.0.0/15  559e239d-f744-4f84-bbe0-c7c6fd12ec17  dynamic  vnet     1
 ```
 
-```
+```bash
 # Check running Pod IPs
 kubectl get pods --field-selector spec.nodeName=aks-agentpool-12345678-vmss000000,status.phase=Running -A -o json | jq -r '.items[] | select(.spec.hostNetwork != 'true').status.podIP' | wc -l
 21

--- a/docs/operator-guides/aks/troubleshoot-network-aks.md
+++ b/docs/operator-guides/aks/troubleshoot-network-aks.md
@@ -99,7 +99,7 @@ Check the allocated IP addresses in the plugin IPAM store. You might find that a
 ```bash
 # Kubenet, for example. The actual path of the IPAM store file depends on network plugin implementation. 
 chroot /host/
-ls -la "/var/lib/cni/networks/$(ls /var/lib/cni/networks/ | grep -e "k8s-pod-network" -e "kubenet")" | grep -v -e "lock\|last\|total" -e '\.$' | more | wc -l
+ls -la "/var/lib/cni/networks/$(ls /var/lib/cni/networks/ | grep -e "k8s-pod-network" -e "kubenet")" | grep -v -e "lock\|last\|total" -e '\.$' | wc -l
 244
 ```
 

--- a/docs/operator-guides/aks/troubleshoot-network-aks.md
+++ b/docs/operator-guides/aks/troubleshoot-network-aks.md
@@ -78,19 +78,52 @@ create pod sandbox: rpc error: code = Unknown desc = NetworkPlugin cni failed to
 delegate: Failed to allocate address: No available addresses 
 ```
 
+Another example of the error:
+
+```output
+Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox 
+'ac1b1354613465324654c1588ac64f1a756aa32f14732246ac4132133ba21364': plugin type='azure-vnet' 
+failed (add): IPAM Invoker Add failed with error: Failed to get IP address from CNS with error: 
+%w: AllocateIPConfig failed: not enough IPs available for 9c6a7f37-dd43-4f7c-a01f-1ff41653609c, 
+waiting on Azure CNS to allocate more with NC Status: , IP config request is [IPConfigRequest: 
+DesiredIPAddress , PodInterfaceID a1876957-eth0, InfraContainerID 
+a1231464635654a123646565456cc146841c1313546a515432161a45a5316541, OrchestratorContext 
+{'PodName':'a_podname','PodNamespace':'my_namespace'}]
+```
+
+
 Check the allocated IP addresses in the plugin IPAM store. You might find that all IP addresses are allocated, but the number is much less than the number of running Pods:
+
+**If using [`kubenet`](/azure/aks/configure-kubenet):**
 
 ```bash
 # Kubenet, for example. The actual path of the IPAM store file depends on network plugin implementation. 
 chroot /host/
-cd /var/lib/cni/networks/k8s-pod-network
-ls -la | grep -v -e "lock\|last" -e '\.$' | wc -l
-258 
+ls -la "/var/lib/cni/networks/$(ls /var/lib/cni/networks/ | grep -e "k8s-pod-network" -e "kubenet")" | grep -v -e "lock\|last\|total" -e '\.$' | more | wc -l
+244
 ```
+
+> [!NOTE]
+> For `kubenet` without `calico`, the path is `/var/lib/cni/networks/kubenet`. For `kubenet` with `calico`, the path is `/var/lib/cni/networks/k8s-pod-network`. In this demo, it will auto-select the path while executing the command.
+
 ```bash
 # Check running Pod IPs
 kubectl get pods --field-selector spec.nodeName=<your_node_name>,status.phase=Running -A -o json | jq -r '.items[] | select(.spec.hostNetwork != 'true').status.podIP' | wc -l
 7 
+```
+
+**If using [`Azure CNI for dynamic IP allocation`](/azure/aks/configure-azure-cni-dynamic-ip-allocation):**
+
+```
+kubectl get nnc -n kube-system -o wide
+NAME                               REQUESTED IPS  ALLOCATED IPS  SUBNET  SUBNET CIDR   NC ID                                 NC MODE  NC TYPE  NC VERSION
+aks-agentpool-12345678-vmss000000  32             32             subnet  10.18.0.0/15  559e239d-f744-4f84-bbe0-c7c6fd12ec17  dynamic  vnet     1
+```
+
+```
+# Check running Pod IPs
+kubectl get pods --field-selector spec.nodeName=aks-agentpool-12345678-vmss000000,status.phase=Running -A -o json | jq -r '.items[] | select(.spec.hostNetwork != 'true').status.podIP' | wc -l
+21
 ```
 
 **Cause 1**

--- a/docs/operator-guides/aks/troubleshoot-network-aks.md
+++ b/docs/operator-guides/aks/troubleshoot-network-aks.md
@@ -82,11 +82,14 @@ Check the allocated IP addresses in the plugin IPAM store. You might find that a
 
 ```bash
 # Kubenet, for example. The actual path of the IPAM store file depends on network plugin implementation. 
-cd /var/lib/cni/networks/kubenet 
-ls -al|wc -l 
+chroot /host/
+cd /var/lib/cni/networks/k8s-pod-network
+ls -la | grep -v -e "lock\|last" -e '\.$' | wc -l
 258 
-
-docker ps | grep POD | wc -l 
+```
+```bash
+# Check running Pod IPs
+kubectl get pods --field-selector spec.nodeName=<your_node_name>,status.phase=Running -A -o json | jq -r '.items[] | select(.spec.hostNetwork != 'true').status.podIP' | wc -l
 7 
 ```
 

--- a/docs/operator-guides/aks/troubleshoot-network-aks.md
+++ b/docs/operator-guides/aks/troubleshoot-network-aks.md
@@ -91,7 +91,6 @@ a1231464635654a123646565456cc146841c1313546a515432161a45a5316541, OrchestratorCo
 {'PodName':'a_podname','PodNamespace':'my_namespace'}]
 ```
 
-
 Check the allocated IP addresses in the plugin IPAM store. You might find that all IP addresses are allocated, but the number is much less than the number of running Pods:
 
 **If using [kubenet](/azure/aks/configure-kubenet):**


### PR DESCRIPTION
**Describe the summary, scope, and intent of this PR:**  
The current commands are outdated:
1. Path not correct (refer to kubenet, aka scenario used in this article)
2. AKS is no longer using `docker` but `containerd`. Commands needs to be modified.

**Insert links(s) to any related work item(s) or supporting detail:**  
> kubernetes support for Docker via dockershim is now removed
https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/

**The change to point 1 includes:**
1. Even the original command in the old environment is wrong, because if you execute that command, you can see:
/var/lib/cni/networks/k8s-pod-network# ls -la
total 56
**drwxr-xr-x 2 root root 4096 Mar  5 11:34 .
drwxr-xr-x 3 root root 4096 Feb  8 04:38 ..**
-rw-r--r-- 1 root root   70 Mar  5 00:46 198.18.1.17
-rw-r--r-- 1 root root   70 Mar  5 00:46 198.18.1.18
-rw-r--r-- 1 root root   70 Mar  5 00:46 198.18.1.19
-rw-r--r-- 1 root root   70 Mar  5 00:46 198.18.1.20
-rw-r--r-- 1 root root   70 Mar  5 00:46 198.18.1.21
-rw-r--r-- 1 root root   70 Mar  5 00:46 198.18.1.23
-rw-r--r-- 1 root root   70 Mar  5 00:46 198.18.1.25
-rw-r--r-- 1 root root   70 Mar  5 00:46 198.18.1.27
-rw-r--r-- 1 root root   70 Mar  5 00:46 198.18.1.30
-rw-r--r-- 1 root root   70 Mar  5 00:46 198.18.1.31
-rw-r--r-- 1 root root   70 Mar  5 00:46 198.18.1.32
-rw-r--r-- 1 root root   12 Mar  5 11:34 last_reserved_ip.0
-rwxr-x--- 1 root root    0 Feb  8 04:38 lock

The line `drwxr-xr-x 2 root root 4096 Mar  5 11:34 .` and line `drwxr-xr-x 3 root root 4096 Feb  8 04:38 ..` are included, which makes IP numbers increased by 2 (not correct number).  

So based on current environment, I exclude the lines, including: `(ends with) .`, `last` and `lock` in order to get the correct number of IP allocated. This should be fair enough.  

**Some outputs for result integrity check (for point 2):**
```
kubectl get pods --field-selector spec.nodeName=aks-userpool-25748257-vmss000000,status.phase=Running -A -o json | jq -r '.items[] | select(.spec.hostNetwork != 'true').status.podIP'
198.18.1.25
198.18.1.23
198.18.1.27
198.18.1.20
198.18.1.30
198.18.1.18
198.18.1.21
198.18.1.31
198.18.1.19
198.18.1.17
198.18.1.32
```

```
kubectl get pods --field-selector spec.nodeName=aks-userpool-25748257-vmss000000,status.phase=Running -A -o wide
NAMESPACE           NAME                                       READY   STATUS    RESTARTS       AGE    IP            NODE                               NOMINATED NODE   READINESS GATES
calico-system       calico-kube-controllers-776b76df8f-lmbvk   1/1     Running   0              25h    198.18.1.25   aks-userpool-25748257-vmss000000   <none>           <none>
calico-system       calico-node-xwpb6                          1/1     Running   0              8h     10.2.0.4      aks-userpool-25748257-vmss000000   <none>           <none>
calico-system       calico-typha-7b8cf7bb4b-9j727              1/1     Running   0              25h    10.2.0.4      aks-userpool-25748257-vmss000000   <none>           <none>
default             test-anykap-6xp8v                          1/1     Running   5 (10h ago)    5d2h   10.2.0.4      aks-userpool-25748257-vmss000000   <none>           <none>
gatekeeper-system   gatekeeper-audit-59875b6cdc-gtwtq          1/1     Running   0              25h    198.18.1.23   aks-userpool-25748257-vmss000000   <none>           <none>
gatekeeper-system   gatekeeper-controller-58498fccdc-d48ck     1/1     Running   0              25h    198.18.1.27   aks-userpool-25748257-vmss000000   <none>           <none>
kube-system         ama-logs-tqkm5                             3/3     Running   21 (10h ago)   7d9h   198.18.1.20   aks-userpool-25748257-vmss000000   <none>           <none>
kube-system         ama-metrics-node-jkhbk                     2/2     Running   58 (10h ago)   26d    198.18.1.30   aks-userpool-25748257-vmss000000   <none>           <none>
kube-system         azure-policy-6664f4bd9d-djsv5              1/1     Running   0              25h    198.18.1.18   aks-userpool-25748257-vmss000000   <none>           <none>
kube-system         azure-policy-webhook-7f584845c-p8lcm       1/1     Running   0              25h    198.18.1.21   aks-userpool-25748257-vmss000000   <none>           <none>
kube-system         cloud-node-manager-5b47d                   1/1     Running   10 (10h ago)   12d    10.2.0.4      aks-userpool-25748257-vmss000000   <none>           <none>
kube-system         coredns-789789675-hp75n                    1/1     Running   0              25h    198.18.1.31   aks-userpool-25748257-vmss000000   <none>           <none>
kube-system         csi-azuredisk-node-4jnw5                   3/3     Running   63 (10h ago)   26d    10.2.0.4      aks-userpool-25748257-vmss000000   <none>           <none>
kube-system         csi-azurefile-node-qqtc8                   3/3     Running   63 (10h ago)   26d    10.2.0.4      aks-userpool-25748257-vmss000000   <none>           <none>
kube-system         konnectivity-agent-896ffc9db-s4kls         1/1     Running   0              25h    198.18.1.19   aks-userpool-25748257-vmss000000   <none>           <none>
kube-system         kube-proxy-ndqzc                           1/1     Running   21 (10h ago)   26d    10.2.0.4      aks-userpool-25748257-vmss000000   <none>           <none>
kube-system         metrics-server-6df4669546-5996g            2/2     Running   0              25h    198.18.1.17   aks-userpool-25748257-vmss000000   <none>           <none>
kube-system         metrics-server-6df4669546-r94ld            2/2     Running   0              25h    198.18.1.32   aks-userpool-25748257-vmss000000   <none>           <none>
tigera-operator     tigera-operator-77bd6c5f5-nwz9d            1/1     Running   0              10h    10.2.0.4      aks-userpool-25748257-vmss000000   <none>           <none>
```
  
**Conclusion:** The commands provided in this PR can exclude the Pods using hostNetwork, which should be excluded, to get correct number of running Pod IPs for troubleshooting IP allocation issue.

Check if command can be executed:
```
kubectl get pods --field-selector spec.nodeName=aks-userpool-25748257-vmss000000,status.phase=Running -A -o json | jq -r '.items[] | select(.spec.hostNetwork != 'true').status.podIP' | wc -l
11
```


<details><summary>AFTER YOUR PR HAS BEEN CREATED, expand this section for tips and additional instructions.</summary>    
      

These are common guidelines for contributions across the repos managed by the Cloud Architecture Content Team (CACT). Some repositories may have additional specific requirements that are not listed here.   

## Guidance for all contributors  
  
  | **Topic** | **Guidance** |
  | ----------| ------------ |
  | **Draft PR** | If your PR will be a work-in-progress for more than a day or two, select the **Convert to draft** link in the upper right of the page (under **Reviewers**) to change it to a draft. For future reference, you can also do this using the **Create pull request** button drop-down during PR creation. | 
  | **ms.date metadata** | <ul><li>Don't update an article's "ms.date" metadata property unless you've done a **full freshness review** of the content. A full freshness review includes changes required to correct or improve the **full** technical accuracy of the article.</li><li>Don't update "ms.date" if you're doing targeted changes to improve non-technical aspects of the article, such as editorial quality, art improvements, article template alignment, etc.</li><li>If you've changed any "ms.date" properties for work that wasn't part of full review for freshness, please reset them to their previous value.</li></ul> | 
  | **Placement and linking** | If you're creating a new article or articles, include updates to the related TOC.yml file to propose where the article(s) should be placed. Also consider other places within the document set where it would be beneficial to cross-reference and link to your new article(s). | 
  | **PR build** | After you open your PR, and for each successive commit that you push to your branch, the publishing platform will run validation on the files in your pull request. A summary of the build results for each file will be inserted inline into your pull request, which includes any build suggestions/warnings/errors. PRs cannot be merged until all build errors and most warnings are resolved. |
  | **Publishing** | Following a successful merge, most repos publish to the live site at least once per (business) day, usually around 10am Pacific. |
  | **Additional resources** | <ul><li>[Learn.Microsoft.Com contributor guide](https://review.learn.microsoft.com/help/contribute/?branch=main)</li></ul>
  
## Additional guidance for private repos and internal contributors  

  | **Topic** | **Guidance** | 
  | ----------| ------------ | 
  | **PR size** | If your PR is more than ~5 lines of changes, or you'd like for the changes to go through editorial or larger review, open a contribution request at https://aka.ms/Contribution and include a link to the PR in response #8. Once it's processed, you'll be notified of the next steps.  |
  | **PR title prefix** | Select the **Edit** button to the right of the PR title if you need to revise it. The following prefixes are reserved for specific contribution types:<br/><br/><ul><li>**[Quality Check]** - maintenance work related to content quality (edit passes, art improvements, template alignment)</li><li>**[LinkFix]** - recurring/adhoc PRs to correct link URLs</li><li>**[Pipeline]** - new/updated contributor success pipeline content</li><li>**[WIP]** - a work-in-progress draft requiring several days/weeks</li></ul> |
  | **PR preview** | Following successful build of your PR, publishable files will also include **Preview URL** links to staged previews of your new/updated articles. Be sure to review these for verification of your intended contributions, or to send to other internal contributors for review. |
  | **PR sign-off (public repo)** | If an article you own is updated in a public repo PR, you are responsible for sign-off. You will be automatically notified via email. The PR will not be merged until you've had a chance to review and sign-off. |
  | **PR sign-off (private repo)** | After you've completed your proposed changes, addressed build warnings, and completed all review work, you can begin the sign-off process for review and merge:<br/><br/><ol><li>If your PR is in draft mode, remove "[WIP]" from the title and select **Ready for review** button at the bottom of the PR.</li><li>Enter "#sign-off" in a new comment. This comment indicates that **you're confident the work meets or exceeds Microsoft's standards for publication**, and will trigger the review process.</li><li>Your PR may be selected for initial review by the CACT. Following CACT review, you may receive questions or requests for additional changes. You should have initial feedback from CACT review within a few business days. If you have an urgent request or need to contact the team, please mention `@MicrosoftDocs/cloud-architecture-content-team-pr-reviewers` in your PR and someone will get back to you. After CACT review is complete, a `CACT #sign-off` will be added.</li><li>Final review/merge is done by the PR review team. The PR team may also respond with feedback, categorized as "Blocking" (requires action from you), or "Non-blocking" (to be addressed in a future PR).</li></ol> |
  | **Additional resources** | <ul><li>[Learn.Microsoft.Com internal contributor guide](https://review.learn.microsoft.com/help/contribute/?branch=main)</li><li>Authoring templates: [architecture-center-pr](https://review.learn.microsoft.com/help/contribute/architecture-center/templates/sample-solution-templates?branch=main), [well-architected-pr](https://review.learn.microsoft.com/help/contribute/global-waf-template?branch=main)</li><li>To contact the CACT use [e-mail](mailto:cact-pr-reviewers@microsoft.com?subject=Help%20with%20pull%20request), or @mention our GitHub team in your PR comments using: `@MicrosoftDocs/cloud-architecture-content-team-pr-reviewers`</li></ul>
</details>