### PR TITLE
Update deprecated SDK references in Improper Instantiation antipattern

### DIFF
--- a/docs/antipatterns/improper-instantiation/index.md
+++ b/docs/antipatterns/improper-instantiation/index.md
@@ -23,8 +23,8 @@ Sometimes new instances of a class are continually created, when it's meant to b
 Many libraries provide abstractions of external resources. Internally, these classes typically manage their own connections to the resource, acting as brokers that clients can use to access the resource. Here are some examples of broker classes that are relevant to Azure applications:
 
 - `System.Net.Http.HttpClient`. Communicates with a web service using HTTP.
-- `Microsoft.ServiceBus.Messaging.QueueClient`. Posts and receives messages to a Service Bus queue.
-- `Microsoft.Azure.Documents.Client.DocumentClient`. Connects to an Azure Cosmos DB instance.
+- `Azure.Messaging.ServiceBus.ServiceBusClient`. Connects to Azure Service Bus for sending and receiving messages.
+- `Microsoft.Azure.Cosmos.CosmosClient`. Connects to an Azure Cosmos DB instance.
 - `StackExchange.Redis.ConnectionMultiplexer`. Connects to Redis, including Azure Managed Redis.
 
 These classes are intended to be instantiated once and reused throughout the lifetime of an application. However, it's a common misunderstanding that these classes should be acquired only as necessary and released quickly. (The ones listed here happen to be .NET libraries, but the pattern isn't unique to .NET.) The following ASP.NET example creates an instance of `HttpClient` to communicate with a remote service.
@@ -96,6 +96,9 @@ public class SingleHttpClientInstanceController : ApiController
 }
 ```
 
+> [!NOTE]
+> In modern .NET applications, the recommended approach for managing `HttpClient` instances is to use [`IHttpClientFactory`](/dotnet/core/extensions/httpclient-factory), which manages handler lifetimes and ensures timely DNS updates. The static singleton pattern shown above remains valid for simpler scenarios or non-DI environments, especially when combined with `PooledConnectionLifetime`.
+
 ## Considerations
 
 - The key element of this antipattern is repeatedly creating and destroying instances of a *shareable* object. If a class isn't shareable (not thread-safe), then this antipattern doesn't apply.
@@ -108,7 +111,7 @@ public class SingleHttpClientInstanceController : ApiController
 
 - Some resource types are scarce and should not be held onto. Database connections are an example. Holding an open database connection that isn't required might prevent other concurrent users from gaining access to the database.
 
-- In the .NET Framework, many objects that establish connections to external resources are created by using static factory methods of other classes that manage these connections. These objects are intended to be saved and reused, rather than disposed and re-created. For example, in Azure Service Bus, the `QueueClient` object is created through a `MessagingFactory` object. Internally, the `MessagingFactory` manages connections. For more information, see [Best Practices for performance improvements using Service Bus Messaging][service-bus-messaging].
+- In .NET, many objects that establish connections to external resources manage those connections internally. These objects are intended to be saved and reused, rather than disposed and re-created. For example, in Azure Service Bus, the `ServiceBusClient` object manages the AMQP connection to the namespace and is used to create `ServiceBusSender` and `ServiceBusReceiver` instances. Create one `ServiceBusClient` and reuse it for the lifetime of the application. For more information, see [Best Practices for performance improvements using Service Bus Messaging][service-bus-messaging].
 
 ## How to detect improper instantiation antipattern
 


### PR DESCRIPTION
#### Summary and intent of this proposed change

Updates two deprecated/renamed Azure SDK client references in the Improper Instantiation antipattern article, and adds a note about the modern `IHttpClientFactory` approach.

| Area | Before | After |
|------|--------|-------|
| Broker class list | `Microsoft.ServiceBus.Messaging.QueueClient` | `Azure.Messaging.ServiceBus.ServiceBusClient` |
| Broker class list | `Microsoft.Azure.Documents.Client.DocumentClient` | `Microsoft.Azure.Cosmos.CosmosClient` |
| Considerations section | References `MessagingFactory` and `.NET Framework`-specific factory pattern | Describes current `ServiceBusClient` → `ServiceBusSender`/`ServiceBusReceiver` pattern |
| How to fix section | Only shows static singleton | Adds `[!NOTE]` callout pointing to `IHttpClientFactory` as the modern alternative |

**Why:**
- **Service Bus SDK**: `WindowsAzure.ServiceBus` and `Microsoft.Azure.ServiceBus` retire 30 September 2026. The current SDK is `Azure.Messaging.ServiceBus`. Source: [Service Bus performance best practices](https://learn.microsoft.com/azure/service-bus-messaging/service-bus-performance-improvements).
- **Cosmos DB SDK**: `DocumentClient` was renamed to `CosmosClient` in the .NET SDK v3 migration. Source: [Migrate to .NET SDK v3](https://learn.microsoft.com/azure/cosmos-db/migrate-dotnet-v3#major-name-changes-from-v2-sdk-to-v3-sdk).
- **HttpClient**: The static singleton remains valid but `IHttpClientFactory` is the recommended approach in DI-enabled .NET applications. Source: [IHttpClientFactory documentation](https://learn.microsoft.com/dotnet/core/extensions/httpclient-factory).

This is **not** a full freshness pass. Only out-of-date SDK references were updated. No changes to metadata (`ms.date`), code samples, images, or article structure.

#### Links to any related work item(s) or supporting detail

- Flagged — deprecated SDK references in antipattern article

#### Checklist

- [x] I gave this PR a meaningful title.
- [ ] I addressed all GitHub Copilot feedback.
- [ ] I addressed all Learn Authoring Assistant feedback.
- [x] I am ready for the Azure Patterns & Practices team to review and provide feedback