### PR TITLE
[NSP] stream processing stream analytics

### DIFF
--- a/docs/reference-architectures/data/stream-processing-stream-analytics-content.md
+++ b/docs/reference-architectures/data/stream-processing-stream-analytics-content.md
@@ -148,6 +148,20 @@ In the architecture shown here, only the results of the Stream Analytics job are
 
 These considerations implement the pillars of the Azure Well-Architected Framework, which is a set of guiding tenets that can be used to improve the quality of a workload. For more information, see [Microsoft Azure Well-Architected Framework](/azure/well-architected/).
 
+### Security
+
+Security provides assurances against deliberate attacks and the misuse of your valuable data and systems. For more information, see [Design review checklist for Security](/azure/well-architected/security/checklist).
+
+#### Restrict network access to PaaS resources
+
+This architecture doesn't use [private endpoints](/azure/private-link/private-link-overview) for Event Hubs, so it remains reachable over its public endpoint to any client that has valid credentials. As an alternative, use [Azure Network Security Perimeter](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) to associate `Microsoft.EventHub/namespaces` with a shared perimeter and deny public traffic by default. Azure Cosmos DB support for network security perimeter is in public preview, so don't rely on it as your primary network control for the Azure Cosmos DB account until it reaches general availability.
+
+Network security perimeter defines both inbound and outbound access rules. Inbound rules control which callers can reach a perimeter member and support two types: subscription-based and IP-based. Outbound rules control which external destinations a perimeter member can reach and are FQDN-based only. Because Event Hubs is the perimeter member in this scenario, its inbound rules determine which producers and consumers are allowed in.
+
+The article doesn't specify where the taxi devices or the .NET data generator that simulates them run, or whether they have a fixed or known public IP range. If they run as Azure resources in a known subscription, a subscription-based inbound rule could allow them. If they have a fixed IP range instead, an IP-based inbound rule could allow that range. Confirm the actual origin and network characteristics of your producers before choosing a rule type.
+
+This architecture doesn't deploy the Stream Analytics job into a custom virtual network, so it has no static outbound IP address. Scope the Event Hubs inbound access rule for the Stream Analytics consumer by subscription (the subscription that hosts the Stream Analytics job) rather than by IP range, which requires a stable, known source IP to be effective.
+
 ### Cost Optimization
 
 Cost Optimization is about looking at ways to reduce unnecessary expenses and improve operational efficiencies. For more information, see [Design review checklist for Cost Optimization](/azure/well-architected/cost-optimization/checklist).

--- a/docs/reference-architectures/data/stream-processing-stream-analytics-content.md
+++ b/docs/reference-architectures/data/stream-processing-stream-analytics-content.md
@@ -154,7 +154,7 @@ Security provides assurances against deliberate attacks and the misuse of your v
 
 #### Restrict network access to PaaS resources
 
-This architecture doesn't use [private endpoints](/azure/private-link/private-link-overview) for Event Hubs, so it remains reachable over its public endpoint to any client that has valid credentials. As an alternative, use [Azure Network Security Perimeter](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) to associate `Microsoft.EventHub/namespaces` with a shared perimeter and deny public traffic by default. Azure Cosmos DB support for network security perimeter is in public preview, so don't rely on it as your primary network control for the Azure Cosmos DB account until it reaches general availability.
+This architecture doesn't use [private endpoints](/azure/private-link/private-link-overview) for Event Hubs, so it remains reachable over its public endpoint to any client that has valid credentials. As an alternative, use [Azure Network Security Perimeter](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) to associate `Microsoft.EventHub/namespaces` with a shared perimeter and deny public traffic by default. Azure Cosmos DB support for network security perimeter is in public preview.
 
 Network security perimeter defines both inbound and outbound access rules. Inbound rules control which callers can reach a perimeter member and support two types: subscription-based and IP-based. Outbound rules control which external destinations a perimeter member can reach and are FQDN-based only. Because Event Hubs is the perimeter member in this scenario, its inbound rules determine which producers and consumers are allowed in.
 

--- a/docs/reference-architectures/data/stream-processing-stream-analytics-content.md
+++ b/docs/reference-architectures/data/stream-processing-stream-analytics-content.md
@@ -154,13 +154,15 @@ Security provides assurances against deliberate attacks and the misuse of your v
 
 #### Restrict network access to PaaS resources
 
-This architecture doesn't use [private endpoints](/azure/private-link/private-link-overview) for Event Hubs, so it remains reachable over its public endpoint to any client that has valid credentials. As an alternative, use [Azure Network Security Perimeter](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) to associate `Microsoft.EventHub/namespaces` with a shared perimeter and deny public traffic by default. Azure Cosmos DB support for network security perimeter is in public preview.
+This architecture uses [Azure Network Security Perimeter](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) to restrict access to Event Hubs. Associate `Microsoft.EventHub/namespaces` with a shared perimeter and deny public traffic by default.
 
 Network security perimeter defines both inbound and outbound access rules. Inbound rules control which callers can reach a perimeter member and support two types: subscription-based and IP-based. Outbound rules control which external destinations a perimeter member can reach and are FQDN-based only. Because Event Hubs is the perimeter member in this scenario, its inbound rules determine which producers and consumers are allowed in.
 
 The article doesn't specify where the taxi devices or the .NET data generator that simulates them run, or whether they have a fixed or known public IP range. If they run as Azure resources in a known subscription, a subscription-based inbound rule could allow them. If they have a fixed IP range instead, an IP-based inbound rule could allow that range. Confirm the actual origin and network characteristics of your producers before choosing a rule type.
 
 This architecture doesn't deploy the Stream Analytics job into a custom virtual network, so it has no static outbound IP address. Scope the Event Hubs inbound access rule for the Stream Analytics consumer by subscription (the subscription that hosts the Stream Analytics job) rather than by IP range, which requires a stable, known source IP to be effective.
+
+As an alternative, you can use [private endpoints](/azure/private-link/private-link-overview) for Event Hubs. This approach removes public endpoint access for Event Hubs and requires private DNS and private connectivity planning in your network design.
 
 ### Cost Optimization
 


### PR DESCRIPTION
#### Summary and intent of this proposed change

Adds a new Security section to the stream-processing Stream Analytics reference architecture with guidance to use Azure Network Security Perimeter (NSP) for Event Hubs (`Microsoft.EventHub/namespaces`) when private endpoints aren't used. The update clarifies how NSP inbound and outbound rules apply in this scenario, notes that producer origin must be validated before choosing subscription-based versus IP-based inbound rules, and recommends subscription-scoped inbound access for the Stream Analytics consumer path because this architecture doesn't use a custom virtual network with a static outbound IP. It also notes that Azure Cosmos DB NSP support is currently in public preview.

#### Links to any related work item(s) or supporting detail

#### Checklist

- [x] I gave this PR a meaningful title.
- [ ] I addressed all GitHub Copilot feedback.
- [ ] I addressed all Learn Authoring Assistant feedback.
- [x] I am ready for the Azure Patterns & Practices team to review and provide feedback
