### PR TITLE
[NSP] aks-microservices

### DIFF
--- a/docs/reference-architectures/containers/aks-microservices/aks-microservices-content.md
+++ b/docs/reference-architectures/containers/aks-microservices/aks-microservices-content.md
@@ -269,6 +269,12 @@ Use a solution like Key Vault to get the following advantages:
 
 This architecture uses a managed identity for microservices to authenticate to Key Vault and access secrets.
 
+#### Restrict network access to PaaS resources
+
+This architecture doesn't use [private endpoints](/azure/private-link/private-link-overview) for Service Bus or Key Vault, so both remain reachable over their public endpoints to any client that has valid credentials. As an alternative, use [Azure Network Security Perimeter](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) to associate `Microsoft.ServiceBus/namespaces` and `Microsoft.KeyVault/vaults` with a shared perimeter and deny public traffic by default. 
+
+This architecture doesn't route egress through a NAT gateway or an egress firewall, so the AKS cluster has no static outbound IP address. Scope inbound access rules by subscription (the subscription that hosts the AKS cluster) rather than by IP range, which requires a stable, known source IP to be effective. If you later adopt a solution like Azure Firewall with SNAT to give the cluster a static egress identity, you can scope the rules to that static IP instead.
+
 #### Container and orchestrator security
 
 The following recommended practices can help secure your pods and containers:

--- a/docs/reference-architectures/containers/aks-microservices/aks-microservices-content.md
+++ b/docs/reference-architectures/containers/aks-microservices/aks-microservices-content.md
@@ -271,9 +271,11 @@ This architecture uses a managed identity for microservices to authenticate to K
 
 #### Restrict network access to PaaS resources
 
-This architecture doesn't use [private endpoints](/azure/private-link/private-link-overview) for Service Bus or Key Vault, so both remain reachable over their public endpoints to any client that has valid credentials. As an alternative, use [Azure Network Security Perimeter](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) to associate `Microsoft.ServiceBus/namespaces` and `Microsoft.KeyVault/vaults` with a shared perimeter and deny public traffic by default. 
+This architecture uses [Azure Network Security Perimeter](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) to restrict access to Service Bus and Key Vault. Associate `Microsoft.ServiceBus/namespaces` and `Microsoft.KeyVault/vaults` with a shared perimeter and deny public traffic by default.
 
-This architecture doesn't route egress through a NAT gateway or an egress firewall, so the AKS cluster has no static outbound IP address. Scope inbound access rules by subscription (the subscription that hosts the AKS cluster) rather than by IP range, which requires a stable, known source IP to be effective. If you later adopt a solution like Azure Firewall with SNAT to give the cluster a static egress identity, you can scope the rules to that static IP instead.
+This architecture doesn't route egress through a NAT gateway or an egress firewall, so the AKS cluster has no static outbound IP address. Scope perimeter access rules by subscription (the subscription that hosts the AKS cluster) rather than by IP range, which requires a stable, known source IP to be effective. If you later adopt a solution like Azure Firewall with SNAT to give the cluster a static egress identity, you can scope the rules to that static IP instead.
+
+As an alternative, you can use [private endpoints](/azure/private-link/private-link-overview) for Service Bus and Key Vault. This approach removes public endpoint access for those resources and requires private DNS and private connectivity planning in your network design.
 
 #### Container and orchestrator security
 


### PR DESCRIPTION
#### Summary and intent of this proposed change

Adds a new Security subsection to the AKS microservices reference architecture with guidance for restricting network access to PaaS dependencies by using Azure Network Security Perimeter (NSP). The update recommends associating `Microsoft.ServiceBus/namespaces` and `Microsoft.KeyVault/vaults` to a shared perimeter when private endpoints aren't used, so public endpoint exposure is reduced. It also adds architecture-specific rule scoping guidance: because this baseline architecture doesn't use NAT gateway or egress firewall SNAT, the cluster has no static outbound IP, so inbound NSP access should be scoped by subscription rather than by IP range.

#### Links to any related work item(s) or supporting detail

#### Checklist

- [x] I gave this PR a meaningful title.
- [ ] I addressed all GitHub Copilot feedback.
- [ ] I addressed all Learn Authoring Assistant feedback.
- [x] I am ready for the Azure Patterns & Practices team to review and provide feedback
