### PR TITLE
[NSP] analytics-service-bus

### DIFF
--- a/docs/solution-ideas/articles/analytics-service-bus-content.md
+++ b/docs/solution-ideas/articles/analytics-service-bus-content.md
@@ -204,7 +204,7 @@ The following [preconfigured estimate in the Azure pricing calculator](https://a
 
 The estimate includes the following services for this architecture:
 
-- **Azure Service Bus Premium** with one messaging unit for reliable transactional event delivery with private networking support. If Premium-only capabilities aren't required, an alternative is Azure Service Bus Standard with [Azure Network Security Perimeter](/azure/private-link/network-security-perimeter-concepts) for `Microsoft.ServiceBus/namespaces`, which helps reduce public endpoint exposure by applying explicit access rules.
+- **Azure Service Bus Premium** with one messaging unit for reliable transactional event delivery with private networking support. If you don't need Premium-only capabilities such as private endpoints, consider Azure Service Bus Standard with [Azure Network Security Perimeter (NSP)](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) for `Microsoft.ServiceBus/namespaces` to reduce public endpoint exposure by using explicit inbound access rules.
 - **Microsoft Fabric F2 capacity** for eventstream, eventhouse, lakehouse, activator, data agents, and Power BI workloads.
 - **Microsoft Purview Data Governance** for data cataloging, classification, and lineage tracking.
 

--- a/docs/solution-ideas/articles/analytics-service-bus-content.md
+++ b/docs/solution-ideas/articles/analytics-service-bus-content.md
@@ -204,7 +204,7 @@ The following [preconfigured estimate in the Azure pricing calculator](https://a
 
 The estimate includes the following services for this architecture:
 
-- **Azure Service Bus Premium** with one messaging unit for reliable transactional event delivery with private networking support.
+- **Azure Service Bus Premium** with one messaging unit for reliable transactional event delivery with private networking support. If Premium-only capabilities aren't required, an alternative is Azure Service Bus Standard with [Azure Network Security Perimeter](/azure/private-link/network-security-perimeter-concepts) for `Microsoft.ServiceBus/namespaces`.
 - **Microsoft Fabric F2 capacity** for eventstream, eventhouse, lakehouse, activator, data agents, and Power BI workloads.
 - **Microsoft Purview Data Governance** for data cataloging, classification, and lineage tracking.
 

--- a/docs/solution-ideas/articles/analytics-service-bus-content.md
+++ b/docs/solution-ideas/articles/analytics-service-bus-content.md
@@ -204,7 +204,7 @@ The following [preconfigured estimate in the Azure pricing calculator](https://a
 
 The estimate includes the following services for this architecture:
 
-- **Azure Service Bus Premium** with one messaging unit for reliable transactional event delivery with private networking support. If Premium-only capabilities aren't required, an alternative is Azure Service Bus Standard with [Azure Network Security Perimeter](/azure/private-link/network-security-perimeter-concepts) for `Microsoft.ServiceBus/namespaces`.
+- **Azure Service Bus Premium** with one messaging unit for reliable transactional event delivery with private networking support. If Premium-only capabilities aren't required, an alternative is Azure Service Bus Standard with [Azure Network Security Perimeter](/azure/private-link/network-security-perimeter-concepts) for `Microsoft.ServiceBus/namespaces`, which helps reduce public endpoint exposure by applying explicit access rules.
 - **Microsoft Fabric F2 capacity** for eventstream, eventhouse, lakehouse, activator, data agents, and Power BI workloads.
 - **Microsoft Purview Data Governance** for data cataloging, classification, and lineage tracking.
 


### PR DESCRIPTION
#### Summary and intent of this proposed change

Updates the Cost optimization section in the Service Bus and Fabric solution idea to clarify an alternative pricing and network-security path. Specifically, the existing **Azure Service Bus Premium** estimate bullet now adds a sentence indicating that if Premium-only capabilities aren't required, you can use **Azure Service Bus Standard** with **Azure Network Security Perimeter (NSP)** for `Microsoft.ServiceBus/namespaces`.

This PR intentionally limits scope to this single in-place wording update in the cost bullet. No Security section content or architecture flow was changed.

#### Links to any related work item(s) or supporting detail

#### Checklist

- [x] I gave this PR a meaningful title.
- [ ] I addressed all GitHub Copilot feedback.
- [ ] I addressed all Learn Authoring Assistant feedback.
- [x] I am ready for the Azure Patterns & Practices team to review and provide feedback
