### PR TITLE
[NSP] mainframe-data-replication-azure-rdrs

### DIFF
--- a/docs/example-scenario/mainframe/mainframe-data-replication-azure-rdrs-content.md
+++ b/docs/example-scenario/mainframe/mainframe-data-replication-azure-rdrs-content.md
@@ -173,7 +173,7 @@ Security provides assurances against deliberate attacks and the misuse of your v
 
 - Use ExpressRoute or a site-to-site VPN for a more private and efficient connection to Azure from an on-premises environment.
 
-- Use [Azure Network Security Perimeter (NSP)](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) with private endpoints to reduce public endpoint exposure for PaaS resources used in this architecture, such as `Microsoft.EventHub/namespaces`. For inbound access to Event Hubs, prefer subscription ID-based rules for Azure-hosted consumers like Logic Apps, Azure Functions, and VM-based processing when outbound IP addresses aren't stable across services. Use IP-based rules only for paths that have stable, known egress IP ranges.
+- Use [Azure Network Security Perimeter (NSP)](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) with private endpoints to reduce public endpoint exposure for PaaS resources used in this architecture, such as Event Hubs.
 
 - Authenticate Azure resources by using Microsoft Entra ID and manage permissions by using role-based access control.
 

--- a/docs/example-scenario/mainframe/mainframe-data-replication-azure-rdrs-content.md
+++ b/docs/example-scenario/mainframe/mainframe-data-replication-azure-rdrs-content.md
@@ -173,6 +173,8 @@ Security provides assurances against deliberate attacks and the misuse of your v
 
 - Use ExpressRoute or a site-to-site VPN for a more private and efficient connection to Azure from an on-premises environment.
 
+- Use [Azure Network Security Perimeter (NSP)](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) to reduce public endpoint exposure for generally available PaaS resources used in this architecture, such as `Microsoft.EventHub/namespaces` and `Microsoft.KeyVault/vaults`. For inbound access to Event Hubs, prefer subscription-based rules for Azure-hosted consumers like Logic Apps, Azure Functions, and VM-based processing when outbound IP addresses aren't stable across services. Use IP-based rules only for paths that have stable, known egress IP ranges.
+
 - Authenticate Azure resources by using Microsoft Entra ID and manage permissions by using role-based access control.
 
 - Use the database services in Azure to support various security options like Transparent Data Encryption for data at rest, TLS for data in transit, and data encryption while processing to help ensure that your data is always encrypted. For more information, see [Azure security documentation](/azure/security) and [Security baselines for Azure](/security/benchmark/azure/security-baselines-overview).

--- a/docs/example-scenario/mainframe/mainframe-data-replication-azure-rdrs-content.md
+++ b/docs/example-scenario/mainframe/mainframe-data-replication-azure-rdrs-content.md
@@ -173,7 +173,7 @@ Security provides assurances against deliberate attacks and the misuse of your v
 
 - Use ExpressRoute or a site-to-site VPN for a more private and efficient connection to Azure from an on-premises environment.
 
-- Use [Azure Network Security Perimeter (NSP)](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) to reduce public endpoint exposure for generally available PaaS resources used in this architecture, such as `Microsoft.EventHub/namespaces` and `Microsoft.KeyVault/vaults`. For inbound access to Event Hubs, prefer subscription-based rules for Azure-hosted consumers like Logic Apps, Azure Functions, and VM-based processing when outbound IP addresses aren't stable across services. Use IP-based rules only for paths that have stable, known egress IP ranges.
+- Use [Azure Network Security Perimeter (NSP)](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) with private endpoints to reduce public endpoint exposure for PaaS resources used in this architecture, such as `Microsoft.EventHub/namespaces`. For inbound access to Event Hubs, prefer subscription ID-based rules for Azure-hosted consumers like Logic Apps, Azure Functions, and VM-based processing when outbound IP addresses aren't stable across services. Use IP-based rules only for paths that have stable, known egress IP ranges.
 
 - Authenticate Azure resources by using Microsoft Entra ID and manage permissions by using role-based access control.
 


### PR DESCRIPTION
#### Summary and intent of this proposed change

Adds targeted network security guidance to the RDRS mainframe data replication architecture by introducing an Azure Network Security Perimeter (NSP) recommendation in the Security section.

The update scopes NSP examples to generally available resource types that this architecture uses in its messaging and secret-management paths: `Microsoft.EventHub/namespaces` and `Microsoft.KeyVault/vaults`. It also adds architecture-specific inbound rule guidance for Event Hubs: prefer subscription-based rules for Azure-hosted consumers when outbound IP addresses aren't stable across services, and use IP-based rules only for paths that have stable, known egress IP ranges.

#### Links to any related work item(s) or supporting detail

#### Checklist

- [x] I gave this PR a meaningful title.
- [ ] I addressed all GitHub Copilot feedback.
- [ ] I addressed all Learn Authoring Assistant feedback.
- [x] I am ready for the Azure Patterns & Practices team to review and provide feedback
