### PR TITLE
[NSP] process-batch-transactions-content

### DIFF
--- a/docs/example-scenario/mainframe/process-batch-transactions-content.md
+++ b/docs/example-scenario/mainframe/process-batch-transactions-content.md
@@ -97,7 +97,7 @@ Reliability ensures your application can meet the commitments you make to your c
 
 Security provides assurances against deliberate attacks and the abuse of your valuable data and systems. For more information, see [Design review checklist for Security](/azure/well-architected/security/checklist).
 
-- All the components within the Service Bus batch architecture work with Azure security components, such as Microsoft Entra ID, Virtual Network, and encryption.
+- All the components within the Service Bus batch architecture work with Azure security components, such as Microsoft Entra ID, Virtual Network, and encryption. For the messaging plane, use [Azure Network Security Perimeter (NSP)](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) as the primary network control for `Microsoft.ServiceBus/namespaces` by reducing public endpoint exposure through explicit access rules. As an alternative, if you require private endpoint connectivity for Service Bus, use the Premium tier and place private endpoints in the virtual network design so AKS traffic stays on private network paths.
 
 ### Cost Optimization
 

--- a/docs/example-scenario/mainframe/process-batch-transactions-content.md
+++ b/docs/example-scenario/mainframe/process-batch-transactions-content.md
@@ -98,8 +98,7 @@ Reliability ensures your application can meet the commitments you make to your c
 Security provides assurances against deliberate attacks and the abuse of your valuable data and systems. For more information, see [Design review checklist for Security](/azure/well-architected/security/checklist).
 
 - All the components within the Service Bus batch architecture work with Azure security components, such as Microsoft Entra ID, Virtual Network, and encryption.
-- For the messaging plane, use [Azure Network Security Perimeter (NSP)](/azure/service-bus-messaging/network-security-perimeter) as the primary network control for `Microsoft.ServiceBus/namespaces` to reduce public endpoint exposure through explicit access rules.
-- If you require private endpoint connectivity for Service Bus, use the Premium tier and place private endpoints in the virtual network design so traffic between AKS and Service Bus stays on private network paths.
+- For the messaging plane, use [Azure Network Security Perimeter (NSP)](/azure/service-bus-messaging/network-security-perimeter) as the primary network control to reduce public endpoint exposure through explicit access rules. If you require private endpoint connectivity for Service Bus, use the Premium tier and place private endpoints in the virtual network design so traffic between AKS and Service Bus stays on private network paths.
 
 ### Cost Optimization
 

--- a/docs/example-scenario/mainframe/process-batch-transactions-content.md
+++ b/docs/example-scenario/mainframe/process-batch-transactions-content.md
@@ -97,7 +97,9 @@ Reliability ensures your application can meet the commitments you make to your c
 
 Security provides assurances against deliberate attacks and the abuse of your valuable data and systems. For more information, see [Design review checklist for Security](/azure/well-architected/security/checklist).
 
-- All the components within the Service Bus batch architecture work with Azure security components, such as Microsoft Entra ID, Virtual Network, and encryption. For the messaging plane, use [Azure Network Security Perimeter (NSP)](/azure/private-link/network-security-perimeter-concepts#onboarded-private-link-resources) as the primary network control for `Microsoft.ServiceBus/namespaces` by reducing public endpoint exposure through explicit access rules. As an alternative, if you require private endpoint connectivity for Service Bus, use the Premium tier and place private endpoints in the virtual network design so AKS traffic stays on private network paths.
+- All the components within the Service Bus batch architecture work with Azure security components, such as Microsoft Entra ID, Virtual Network, and encryption.
+- For the messaging plane, use [Azure Network Security Perimeter (NSP)](/azure/service-bus-messaging/network-security-perimeter) as the primary network control for `Microsoft.ServiceBus/namespaces` to reduce public endpoint exposure through explicit access rules.
+- If you require private endpoint connectivity for Service Bus, use the Premium tier and place private endpoints in the virtual network design so traffic between AKS and Service Bus stays on private network paths.
 
 ### Cost Optimization
 


### PR DESCRIPTION
#### Summary and intent of this proposed change

Adds targeted network security guidance to the batch transaction processing architecture by updating the Security section of the article.

The change keeps the existing security bullet and extends it with messaging-plane guidance: use Azure Network Security Perimeter (NSP) as the primary network control for `Microsoft.ServiceBus/namespaces` to reduce public endpoint exposure through explicit access rules. It also clarifies the alternative path: when private endpoint connectivity to Service Bus is required, use the Premium tier and place private endpoints in the virtual network design so AKS traffic remains on private network paths.

#### Links to any related work item(s) or supporting detail

#### Checklist

- [X] I gave this PR a meaningful title.
- [ ] I addressed all GitHub Copilot feedback.
- [ ] I addressed all Learn Authoring Assistant feedback.
- [x] I am ready for the Azure Patterns & Practices team to review and provide feedback
