### PR TITLE
Update Sidecar pattern for ambient mesh and native sidecar containers

### DIFF
--- a/docs/patterns/sidecar.md
+++ b/docs/patterns/sidecar.md
@@ -3,7 +3,7 @@ title: Sidecar Pattern
 description: Learn how to deploy features of an application into a separate process or container to provide modular abstraction and isolation of cross-cutting concerns.
 author: claytonsiemens77
 ms.author: pnp
-ms.date: 02/17/2026
+ms.date: 08/27/2026
 ms.topic: design-pattern
 ms.subservice: cloud-fundamentals
 ---
@@ -50,6 +50,8 @@ Consider the following points when you implement this pattern:
 
 - Consider the deployment and packaging format to deploy services, processes, or containers. Containers work well for the Sidecar pattern.
 
+- Consider how your platform manages the sidecar's life cycle relative to the main application. Kubernetes provides native sidecar containers, which guarantee that the sidecar starts before the main application container and terminates after it. This behavior removes the need for custom startup-ordering logic and avoids shutdown races in which the sidecar exits while the application still depends on it. For more information, see [Native sidecar mode for the Istio-based service mesh add-on for AKS](/azure/aks/istio-native-sidecar).
+
 - When you design a sidecar service, carefully choose the interprocess communication mechanism. Use language-agnostic or framework-agnostic technologies unless performance requirements make that approach impractical.
 
 - Before you add functionality to a sidecar, evaluate whether it works better as a separate service or a traditional daemon.
@@ -80,6 +82,8 @@ This pattern might not be suitable when:
 
 - Your platform provides equivalent functionality. If your application platform already provides the needed capabilities natively, sidecars add unnecessary complexity.
 
+- Your service mesh provides a sidecar-less data plane that meets your requirements. A sidecar-less, or *ambient*, data plane avoids the resource overhead of a proxy for each instance, but platform support for it varies. Verify availability on your target platform before you commit to either approach.
+
 ## Workload design
 
 Evaluate how to use the Sidecar pattern in a workload's design to address the goals and principles covered in the [Azure Well-Architected Framework pillars](/azure/well-architected/pillars). The following table provides guidance about how this pattern supports the goals of each pillar.
@@ -102,11 +106,11 @@ You can apply the Sidecar pattern to many scenarios. Consider the following exam
 
 - **Service mesh data plane:** Deploy a sidecar proxy alongside each service instance to handle cross-cutting networking concerns like traffic routing, retries, mutual Transport Layer Security (mTLS), policy enforcement, and telemetry.
 
-  Service meshes like [Istio](https://istio.io/latest/about/service-mesh/) use sidecar proxies to implement these capabilities without requiring changes to application code.
+  Service meshes like [Istio](https://istio.io/latest/about/service-mesh/) use sidecar proxies to implement these capabilities without requiring changes to application code. Some service meshes also offer a sidecar-less, or *ambient*, data plane that moves these concerns to shared node-level and gateway-level components instead of a per-instance proxy. Treat the choice between a sidecar-based and a sidecar-less data plane as an architectural decision, and confirm which modes your platform supports.
 
 - **Ambassador sidecar:** Deploy an [ambassador](./ambassador.md) service as a sidecar. The application routes calls through the ambassador, which handles request logging, routing, circuit breaking, and other connectivity features.
 
-- **Protocol adapters:** Deploy a sidecar to translate between incompatible protocols or data formats, or to [bridge messaging systems](messaging-bridge.yml). This approach lets the application use simpler or legacy interfaces.
+- **Protocol adapters:** Deploy a sidecar to translate between incompatible protocols or data formats, or to [bridge messaging systems](./messaging-bridge.yml). This approach lets the application use simpler or legacy interfaces.
 
 - **Telemetry enrichment:** Deploy a sidecar to preprocess or enrich telemetry data, like metrics, logs, and traces, before it forwards the data to external monitoring systems. Components like the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/deploy/agent/) can run as sidecars to normalize, enrich, or route telemetry separately from the application.
 


### PR DESCRIPTION
## Summary

Content maintenance pass for `docs/patterns/sidecar.md`. The article is in good shape — no broken links, no missing assets, no malformed markup. These changes address two pieces of genuine content drift plus two minor cleanups.

Work item: AB#628707

## Changes

| # | Section | Change |
|---|---------|--------|
| 1 | `## Example` → *Service mesh data plane* | Note that some service meshes offer a sidecar-less (*ambient*) data plane, and frame the sidecar-vs-ambient choice as an architectural decision to confirm against platform support. |
| 2 | `## When to use this pattern` → *might not be suitable when* | New bullet for meshes that provide a sidecar-less data plane. |
| 3 | `## Problems and considerations` | New bullet on Kubernetes native sidecar containers — guaranteed start-before / terminate-after ordering, which removes custom startup-ordering logic and avoids shutdown races. |
| 4 | Front matter | Refresh `ms.date`. |
| 5 | `## Example` → *Protocol adapters* | `](messaging-bridge.yml)` → `](./messaging-bridge.yml)` to match the sibling relative links. |

## Why

**Ambient / sidecar-less data planes (1, 2).** The article currently presents the sidecar proxy as *the* service mesh data plane. First-party docs treat ambient as a distinct, roadmapped alternative, so a reader evaluating this pattern for a mesh has no signal that the alternative exists:

- [Istio service mesh add-on for AKS — limitations](https://learn.microsoft.com/azure/aks/istio-about#limitations): "The add-on doesn't yet support the sidecar-less Ambient mode… Product integration for Ambient mode is on the roadmap."
- [Application Gateway for Containers — service mesh integration](https://learn.microsoft.com/azure/application-gateway/for-containers/service-mesh-integration): "Ambient (sidecar-less) mode isn't supported."

**Native sidecar containers (3).** The article's central lifecycle claim is that sidecars "share its life cycle, so you create and retire them together," but it never mentions that Kubernetes made this a first-class container lifecycle feature. Notably, the article's own **Next steps** section already links the AKS native sidecar doc — the body was behind its own link list.

- [Native sidecar mode for the Istio-based service mesh add-on for AKS](https://learn.microsoft.com/azure/aks/istio-native-sidecar): "the sidecar always starts before the main application. It also shuts down gracefully after the main app. This behavior removes the need for manual workarounds to handle container lifecycle or Pod termination issues." Sidecar containers are enabled on AKS from Kubernetes 1.29; native sidecar became the Istio default starting in version 1.27.

## Verification

- All 9 headings present, unchanged, and in the same order.
- Front matter key set unchanged; only `ms.date` modified.
- `:::image type="complex"` / `:::image-end:::` block untouched; Well-Architected table unchanged (5 rows); `<br>` count unchanged (8).
- No links removed. All referenced assets confirmed to exist in-repo: `_images/sidecar.png`, `ambassador.md`, `messaging-bridge.yml`, `messaging-bridge-content.md`.
- Diff is +7 / −3 lines across a single file, all attributable to the change list above.

No stylistic rewrites — edits are scoped to accuracy and freshness.