### PR TITLE
Add note on transactional messaging support to Compensating Transaction pattern

### DIFF
--- a/docs/patterns/compensating-transaction.md
+++ b/docs/patterns/compensating-transaction.md
@@ -3,7 +3,7 @@ title: Compensating Transaction Pattern
 description: Use the Compensating Transaction pattern to undo work when a step of an eventually consistent operation fails in distributed systems.
 ms.author: pnp
 author: claytonsiemens77
-ms.date: 04/16/2026
+ms.date: 09/02/2026
 ms.topic: design-pattern
 ms.subservice: cloud-fundamentals
 ---
@@ -136,7 +136,7 @@ Use managed identities and Microsoft Entra ID-based authorization between compon
 
 - [Data considerations for microservices](../microservices/design/data-considerations.md): Learn why eventual consistency and partial failure are inherent in distributed systems. The Compensating Transaction pattern provides a concrete mechanism to handle those failures when operations span multiple services.
 
-- [Transactional Outbox pattern with Azure Cosmos DB](../databases/guide/transactional-out-box-cosmos.md): Use this pattern when compensating transactions need to publish events or commands reliably. It helps ensure that state changes and messages are recorded atomically, which prevents message loss.
+- [Transactional Outbox pattern with Azure Cosmos DB](../databases/guide/transactional-out-box-cosmos.md): Use this pattern when compensating transactions need to publish events or commands reliably. It helps ensure that state changes and messages are recorded atomically, which prevents message loss. Separately, if your messaging system supports transactional messaging, you can use it to atomically commit related messaging operations; for example, [Azure Service Bus supports transactional messaging](https://learn.microsoft.com/azure/service-bus-messaging/service-bus-transactions).
 
 - [Design for self-healing](../guide/design-principles/self-healing.md): Use compensating transactions as part of a self-healing approach for your applications.
 


### PR DESCRIPTION
This PR adds a concise note to inform users about their options for reliable event publishing. Even though the page brings up an example about Azure Service Bus, it never mentions that some messaging systems, such as Azure Service Bus, offer their own transactional guarantees for operations; which can be helpful for implementing compensating updates, or, in some cases, even reduce the need for such updates.

[REPLACE-THIS-TEXT]

#### Links to any related work item(s) or supporting detail

- AB#NNNNN
- [DELETE-OR-REPLACE-THIS-TEXT]

#### Checklist

- [x] I gave this PR a meaningful title.
- [x] I addressed all GitHub Copilot feedback.
- [x] I addressed all Learn Authoring Assistant feedback.
- [x] I am ready for the Azure Patterns & Practices team to review and provide feedback
